### PR TITLE
Separate Dialog API

### DIFF
--- a/frappe_docs/www/docs/user/en/api/_sidebar.json
+++ b/frappe_docs/www/docs/user/en/api/_sidebar.json
@@ -63,6 +63,7 @@
 			{ "title": "Database", "route": "/docs/user/en/api/database" },
 			{ "title": "Jinja", "route": "/docs/user/en/api/jinja" },
 			{ "title": "REST API", "route": "/docs/user/en/api/rest" }
+			{ "title": "Dialog API", "route": "/docs/user/en/api/py-dialog" }
 		]
 	},
 	{

--- a/frappe_docs/www/docs/user/en/api/dialog.md
+++ b/frappe_docs/www/docs/user/en/api/dialog.md
@@ -1,3 +1,4 @@
+
 ---
 add_breadcrumbs: 1
 title: Dialog - API
@@ -8,15 +9,8 @@ metatags:
 ---
 
 # Dialog API
-Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use.
+Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use. There's also an API for [Python](./py-dialog)
 
-## Contents
-1. [JavaScript API](#javascript-api)
-2. [Python API](#python-api)
-
-----
-
-## JavaScript API
 ### frappe.ui.Dialog
 `new frappe.ui.Dialog({ title, fields, primary_action })`
 
@@ -268,59 +262,3 @@ new frappe.ui.form.MultiSelectDialog({
 Here all the Material Requests that fulfill the filter criteria will be fetched into the selection area. The setter `company` is added to the filter fields along with its passed value. The `date_field` will be used to fetch and query dates from the DocType mentioned.
 
 The **Make Material Request** (or `Make {DocType}`) secondary action button will redirect you to a new form in order to make a new entry into the DocType passed.
-
-----
-
-## Python API
-### frappe.msgprint
-`frappe.msgprint(msg, title, raise_exception, as_table, indicator, primary_action)`
-
-Shows a message to the user and can optionally throw an exception as well.
-
-The argument list includes:
-
-- `msg`: The message to be displayed
-- `title`: Title to the modal
-- `raise_exception`: Exception
-- `as_table`: If `msg` is a list of lists, render as HTML table
-- `primary_action`: Bind a primary server/client side action.
-
-```py
-frappe.msgprint(msg='This file does not exist',
-	title='Error',
-	raise_exception=FileNotFoundError)
-```
-![MultiSelectDialog](/docs/assets/img/api/dialog-api-msgprint-py.png)
-*frappe.msgprint*
-
-`primary_action` can contain a `server_action` **or** `client_side` action which must contain dotted paths to the respective methods. The JavaScript function must be a globally available function.
-
-```py
-# msgprint with server and client side action
-frappe.msgprint(msg='This file does not exist',
-	title='Error',
-	raise_exception=FileNotFoundError
-	primary_action={
-		'label': _('Perform Action'),
-		'server_action': 'dotted.path.to.method',
-		'client_action': 'dotted_path.to_method',
-		'args': args })
-```
-
-![MultiSelectDialog](/docs/assets/img/api/dialog-api-msgprint-py-with-primary-action.png)
-*frappe.msgprint with primary action*
-
-### frappe.throw
-`frappe.throw(msg, exc, title)`
-
-It is essentially a wrapper around `frappe.msgprint`.
-
-`exc` can be passed an optional exception. By default it will raise a `ValidationError` exception.
-
-```py
-frappe.throw(msg='This file does not exist',
-	exc=FileNotFoundError,
-	title='Error')
-```
-![Throw-py](/docs/assets/img/api/dialog-api-msgprint-py.png)
-*frappe.throw*

--- a/frappe_docs/www/docs/user/en/api/dialog.md
+++ b/frappe_docs/www/docs/user/en/api/dialog.md
@@ -9,7 +9,7 @@ metatags:
 ---
 
 # Dialog API
-Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use. There's also an API for [Python](./py-dialog)
+Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use. There's also an API for [Python](/docs/user/en/api/py-dialog)
 
 ### frappe.ui.Dialog
 `new frappe.ui.Dialog({ title, fields, primary_action })`

--- a/frappe_docs/www/docs/user/en/api/py-dialog.md
+++ b/frappe_docs/www/docs/user/en/api/py-dialog.md
@@ -1,0 +1,67 @@
+---
+add_breadcrumbs: 1
+title: Dialog - API
+image: /assets/frappe_io/images/frappe-framework-logo-with-padding.png
+metatags:
+ description: >
+  API methods for creating and managing Dialogs in Frappe using Python
+---
+
+# Dialog API
+Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use. There's also a more extensive API for [Javascript](./dialog)
+
+----
+
+
+### frappe.msgprint
+`frappe.msgprint(msg, title, raise_exception, as_table, indicator, primary_action)`
+
+Shows a message to the user and can optionally throw an exception as well.
+
+The argument list includes:
+
+- `msg`: The message to be displayed
+- `title`: Title to the modal
+- `raise_exception`: Exception
+- `as_table`: If `msg` is a list of lists, render as HTML table
+- `primary_action`: Bind a primary server/client side action.
+
+```py
+frappe.msgprint(msg='This file does not exist',
+	title='Error',
+	raise_exception=FileNotFoundError)
+```
+![frappe.msgprint](/docs/assets/img/api/dialog-api-msgprint-py.png)
+*frappe.msgprint*
+
+`primary_action` can contain a `server_action` **or** `client_side` action which must contain dotted paths to the respective methods. The JavaScript function must be a globally available function.
+
+```py
+# msgprint with server and client side action
+frappe.msgprint(msg='This file does not exist',
+	title='Error',
+	raise_exception=FileNotFoundError
+	primary_action={
+		'label': _('Perform Action'),
+		'server_action': 'dotted.path.to.method',
+		'client_action': 'dotted_path.to_method',
+		'args': args })
+```
+
+![frappe.msgprint with primary action](/docs/assets/img/api/dialog-api-msgprint-py-with-primary-action.png)
+*frappe.msgprint with primary action*
+
+### frappe.throw
+`frappe.throw(msg, exc, title)`
+
+It is essentially a wrapper around `frappe.msgprint`.
+
+`exc` can be passed an optional exception. By default it will raise a `ValidationError` exception.
+
+```py
+frappe.throw(msg='This file does not exist',
+	exc=FileNotFoundError,
+	title='Error')
+```
+![Throw-py](/docs/assets/img/api/dialog-api-msgprint-py.png)
+*frappe.throw*

--- a/frappe_docs/www/docs/user/en/api/py-dialog.md
+++ b/frappe_docs/www/docs/user/en/api/py-dialog.md
@@ -8,7 +8,7 @@ metatags:
 ---
 
 # Dialog API
-Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use. There's also a more extensive API for [Javascript](./dialog)
+Frappe provides a group of standard, interactive and flexible dialogs that are easy to configure and use. There's also a more extensive API for [Javascript](/docs/user/en/api/dialog)
 
 ----
 

--- a/frappe_docs/www/docs/user/en/understanding-doctypes.md
+++ b/frappe_docs/www/docs/user/en/understanding-doctypes.md
@@ -322,7 +322,7 @@ Method Name | Description
 `before_update_after_submit` | This is called *before* a submitted document values are updated.
 `before_insert`              | This is called before a document is inserted into the database.
 `before_naming`              | This is called before the `name` property of the document is set.
-`autoname`                   | This is an optional method which is called only when it is defined in the controller. Use this method to customize how the `name` property of the document is set.
+`autoname`                   | This is an optional method which is called only when it is defined in the controller at document creation. Use this method to customize how the `name` property of the document is set.
 `validate`                   | Use this method to throw any validation errors and prevent the document from saving.
 `before_save`                | This method is called before the document is saved.
 `after_insert`               | This is called after the document is inserted into the database.


### PR DESCRIPTION
Currently Dialog  API is under Javascript in the Left Hand Menu. So someone looking for doing it in python, won't find anything. Unless they dig. It was also at the bottom of the Dialog API page. This way is split in my opinion is better. Also added links to each other on the page.

It also adds a bit of extra explanation of when the `autoname` controller method is call in the Understanding Doctypes. reference to https://github.com/frappe/frappe_docs/issues/13