### PR TITLE
fix: bench config set-common-config documentation

### DIFF
--- a/frappe_docs/www/docs/user/en/api/py-dialog.md
+++ b/frappe_docs/www/docs/user/en/api/py-dialog.md
@@ -12,7 +12,7 @@ Frappe provides a group of standard, interactive and flexible dialogs that are
 easy to configure and use. There's also a more extensive API for [Javascript](/docs/user/en/api/dialog).
 
 ### frappe.msgprint
-`frappe.msgprint(msg, title, raise_exception, as_table, indicator, primary_action)`
+`frappe.msgprint(msg, title, raise_exception, as_table, as_list, indicator, primary_action)`
 
 This method works only within a request / response cycle. It shows a message to
 the user logged in to Desk who initiated the request.
@@ -22,6 +22,7 @@ The argument list includes:
 - `msg`: The message to be displayed
 - `title`: Title of the modal
 - `as_table`: If `msg` is a list of lists, render as HTML table
+- `as_list`: If `msg` is a list, render as HTML unordered list
 - `primary_action`: Bind a primary server/client side action.
 - `raise_exception`: Exception
 

--- a/frappe_docs/www/docs/user/en/api/py-dialog.md
+++ b/frappe_docs/www/docs/user/en/api/py-dialog.md
@@ -12,7 +12,7 @@ Frappe provides a group of standard, interactive and flexible dialogs that are
 easy to configure and use. There's also a more extensive API for [Javascript](/docs/user/en/api/dialog).
 
 ### frappe.msgprint
-`frappe.msgprint(msg, title, raise_exception, as_table, as_list, indicator, primary_action)`
+`frappe.msgprint(msg, title, raise_exception, as_table, indicator, primary_action)`
 
 This method works only within a request / response cycle. It shows a message to
 the user logged in to Desk who initiated the request.
@@ -22,7 +22,6 @@ The argument list includes:
 - `msg`: The message to be displayed
 - `title`: Title of the modal
 - `as_table`: If `msg` is a list of lists, render as HTML table
-- `as_list`: If `msg` is a list, render as HTML unordered list
 - `primary_action`: Bind a primary server/client side action.
 - `raise_exception`: Exception
 

--- a/frappe_docs/www/docs/user/en/basics/site_config.md
+++ b/frappe_docs/www/docs/user/en/basics/site_config.md
@@ -81,7 +81,7 @@ You can set `enable_frappe_logger` as `true` in the `common_site_config.json`
 and set it to `false` in *worker.frappe.xyz*'s `site_config.json`.
 
 ```bash
-$ bench config set-common-config enable_frappe_logger true
+$ bench config set-common-config -c enable_frappe_logger true
 $ bench --site worker.frappe.xyz set-config enable_frappe_logger false
 ```
 

--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -200,6 +200,12 @@ configurations in the current bench context. The usage for these commands is as
 ```zsh
 ➜ bench config COMMAND [ARGS]...
 ```
+ - **set-common-config**: Set value in common config with parameters -c, configs or --config 
+   
+```zsh
+➜ bench config set-common-config -c enable_frappe_logger true
+```
+
  - **remove-common-config**: Remove specific keys from current bench's common
    config
  - **update\_bench\_on\_update**: Enable/Disable bench updates on running bench
@@ -213,14 +219,7 @@ configurations in the current bench context. The usage for these commands is as
  - **serve\_default\_site**: Configure nginx to serve the default site on port
    80
  - **http\_timeout**: Set HTTP timeout
- 
-There is specials args for this commands
 
- - **set-common-config**: Set value in common config with parameters -c, configs or --config 
-   
-```zsh
-➜ bench config set-common-config -c enable_frappe_logger true
-```
 
 ### Install Commands
 

--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -221,7 +221,7 @@ There is specials args for this two commands
    
 ```zsh
 ➜ bench config set-common-config -c enable_frappe_logger true
-➜ bench config removecommon-config -c enable_frappe_logger true
+➜ bench config remove-common-config -c enable_frappe_logger
 ```
 
 ### Install Commands

--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -200,7 +200,8 @@ configurations in the current bench context. The usage for these commands is as
 ```zsh
 ➜ bench config COMMAND [ARGS]...
 ```
-
+ - **remove-common-config**: Remove specific keys from current bench's common
+   config
  - **update\_bench\_on\_update**: Enable/Disable bench updates on running bench
    update
  - **restart\_supervisor\_on\_update**: Enable/Disable auto restart of
@@ -213,15 +214,12 @@ configurations in the current bench context. The usage for these commands is as
    80
  - **http\_timeout**: Set HTTP timeout
  
-There is specials args for this two commands
+There is specials args for this commands
 
  - **set-common-config**: Set value in common config with parameters -c, configs or --config 
- - **remove-common-config**: Remove specific keys from current bench's common with parameters -c, configs or --config
-   config
    
 ```zsh
 ➜ bench config set-common-config -c enable_frappe_logger true
-➜ bench config remove-common-config -c enable_frappe_logger
 ```
 
 ### Install Commands

--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -141,9 +141,9 @@ each with `bench` in your shell. Therefore, the usage for these commands is as
 
 ### Setup Commands
 
-This command group consists of commands used to manipulate the requirements
-and environments required by your Frappe environment. The setup commands used
-for setting up the Frappe environment in context of the current bench need to be
+This command group consists of commands used to manipulate the requirements and
+the environment required by your Frappe environment. The setup commands used for
+setting up the Frappe environment in the context of the current bench need to be
 executed using `bench setup` as the prefix. So, the general usage of these
 commands is as
 
@@ -184,7 +184,7 @@ commands is as
  - **wildcard-ssl**: Setup wildcard SSL certificate for multi-tenant bench
 
  - **add-domain**: Add a custom domain to a particular site
- - **remove-domain**: Remove custom domain from a site
+ - **remove-domain**: Remove a custom domain from a site
  - **sync-domains**: Check if there is a change in domains. If yes, updates the
    domains list.
 
@@ -200,12 +200,8 @@ configurations in the current bench context. The usage for these commands is as
 ```zsh
 ➜ bench config COMMAND [ARGS]...
 ```
- - **set-common-config**: Set value in common config with parameters -c, configs or --config 
-   
-```zsh
-➜ bench config set-common-config -c enable_frappe_logger true
-```
-
+ - **set-common-config**: Set value in common config with parameters -c, configs
+   or --config
  - **remove-common-config**: Remove specific keys from current bench's common
    config
  - **update\_bench\_on\_update**: Enable/Disable bench updates on running bench
@@ -312,6 +308,25 @@ familiar with the basic usage.
 ➜ bench update
 ```
 
+### Update Bench config
+
+  To update the common site config for your bench, you can use the
+  `set-common-config` and `remove-common-config` commands under the config
+  command group. To learn more about Frappe Site configurations available,
+  checkout the Site and Bench Config
+  [docs](/docs/user/en/guides/basics/site_config).
+
+  To add or update an existing config key, you can run something like
+
+```zsh
+➜ bench config set-common-config -c enable_frappe_logger true
+```
+
+  To remove an existing config key, you can run something like
+
+```zsh
+➜ bench config remove-common-config enable_frappe_logger
+```
 
 ## Bench Manager
 

--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -201,10 +201,6 @@ configurations in the current bench context. The usage for these commands is as
 ➜ bench config COMMAND [ARGS]...
 ```
 
- - **set-common-config**: Set value in common config
- - **remove-common-config**: Remove specific keys from current bench's common
-   config
-
  - **update\_bench\_on\_update**: Enable/Disable bench updates on running bench
    update
  - **restart\_supervisor\_on\_update**: Enable/Disable auto restart of
@@ -216,7 +212,17 @@ configurations in the current bench context. The usage for these commands is as
  - **serve\_default\_site**: Configure nginx to serve the default site on port
    80
  - **http\_timeout**: Set HTTP timeout
+ 
+There is specials args for this two commands
 
+ - **set-common-config**: Set value in common config with parameters -c, configs or --config 
+ - **remove-common-config**: Remove specific keys from current bench's common with parameters -c, configs or --config
+   config
+   
+```zsh
+➜ bench config set-common-config -c enable_frappe_logger true
+➜ bench config removecommon-config -c enable_frappe_logger true
+```
 
 ### Install Commands
 


### PR DESCRIPTION
bench config set-common-config or remove-comon-config need 'configs', '-c', '--config' to send config value
line 53 of bench/commands/config.py

`@click.command('set-common-config', help='Set value in common config')
@click.option('configs', '-c', '--config', multiple=True, type=(str, str))
def set_common_config(configs):`

If this option is not provided, there is error 
for exemple 

```
$bench config set-common-config enable_frappe_logger true
Error: Got unexpected extra argument (enable_frappe_logger)
```
but 

`$bench config set-common-config -c enable_frappe_logger true`

is ok

**Changes**
- Fixed command usage
- Added examples for bench config updation