### PR TITLE
docs: Minor doc fixes

### DIFF
--- a/frappe_docs/www/docs/user/en/basics/directory-structure.md
+++ b/frappe_docs/www/docs/user/en/basics/directory-structure.md
@@ -40,7 +40,7 @@ run the command `bench new-app app_name`, the app will be bootstrapped in this
 directory. Your custom apps live here and you are supposed to edit/work with
 them here.
 
-Learn more about [apps](/docs/user/en/apps).
+Learn more about [apps](/docs/user/en/basics/apps).
 
 ### sites
 

--- a/frappe_docs/www/docs/user/en/basics/doctypes/controllers.md
+++ b/frappe_docs/www/docs/user/en/basics/doctypes/controllers.md
@@ -52,8 +52,8 @@ class Person(Document):
         do_something_else()
 ```
 
-There are a lot of methods provided by default on the `doc` object. You can find the complete [list here](api/document#document-methods).
-.
+There are a lot of methods provided by default on the `doc` object. You can find the complete [list here](/docs/user/en/api/document#document-methods).
+
 
 ### Controller Hooks
 

--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -240,7 +240,7 @@ is as
    for that user
  - **fail2ban**: Install fail2ban, an intrusion prevention software framework
    that protects computer servers from brute-force attacks
- - **virtualbox**: Installs supervisor
+ - **virtualbox**: Installs virtualbox.
 
 
 

--- a/frappe_docs/www/docs/user/en/bench/frappe-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/frappe-commands.md
@@ -90,7 +90,7 @@ backup](/docs/user/en/bench/reference/backup) reference.
 
 You can install or uninstall Frappe Applications available on your Bench. To add
 Apps to your bench using `bench get-app` checkout [the
-docs](/docs/user/en/bench/bench-commands#the-usual-commands).
+docs](/docs/user/en/bench/bench-commands#frequently-used).
 
 ##### App Installation
 

--- a/frappe_docs/www/docs/user/en/desk/index.md
+++ b/frappe_docs/www/docs/user/en/desk/index.md
@@ -17,7 +17,7 @@ for your DocTypes. Desk is to be used by users of the type "System User".
 
 In this section we will discuss what views are provided by Desk and how to configure them.
 
-- [Desktop](#desktop)
+- [Workspace](#Workspace)
 - [Awesomebar](#awesomebar)
 - [List View](#list-view)
 - [Form View](#form-view)
@@ -29,7 +29,7 @@ In this section we will discuss what views are provided by Desk and how to confi
 
 ## Workspace
 
-When you login to the Desk, you're presented with the Desktop, it features a persistent sidebar sorted in categories. 
+When you login to the Desk, you're presented with the Workspace, it features a persistent sidebar sorted in categories.
 Each sidebar item links to a page called Workspace.
 
 A workspace represents a module (for example CRM in ERPNext). A workspace includes the following:

--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -43,7 +43,7 @@ This guide assumes you are using a personal computer, VPS or a bare-metal server
 Install [Homebrew](https://brew.sh/). It makes it easy to install packages on macOS.
 
 ```bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 Now, you can easily install the required packages by running the following command

--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -223,9 +223,6 @@ Add the following configuration
 
 ```
 [mysqld]
-innodb-file-format=barracuda
-innodb-file-per-table=1
-innodb-large-prefix=1
 character-set-client-handshake = FALSE
 character-set-server = utf8mb4
 collation-server = utf8mb4_unicode_ci

--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -53,6 +53,30 @@ brew install python git redis mariadb
 brew cask install wkhtmltopdf
 ```
 
+Now, edit the MariaDB configuration file.
+
+```bash
+nano /etc/mysql/my.cnf
+```
+
+And add this configuration
+
+```hljs
+[mysqld]
+character-set-client-handshake = FALSE
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+[mysql]
+default-character-set = utf8mb4
+```
+
+Now, just restart the mysql service and you are good to go.
+
+```bash
+brew services restart mariadb
+```
+
 **Install Node**
 
 We recommend installing node using [nvm](https://github.com/creationix/nvm)

--- a/frappe_docs/www/docs/user/en/production-setup.md
+++ b/frappe_docs/www/docs/user/en/production-setup.md
@@ -16,7 +16,7 @@ sites on production.
 
 Deploying frappe sites is not too different from setting it up on your local
 system. Install bench using the [Easy
-Install](https://github.com/frappe/bench#easy-install) script if your server is
+Install](https://github.com/frappe/bench#easy-install-script) script if your server is
 one of the supported linux distributions (Debian, Ubuntu, CentOS). Make sure you
 pass the `--production` flag to the script.
 

--- a/frappe_docs/www/docs/user/en/python-api/search.md
+++ b/frappe_docs/www/docs/user/en/python-api/search.md
@@ -11,7 +11,7 @@ metatags:
 
 Searching in Frappe is managed by the [Search](https://github.com/frappe/frappe/blob/develop/frappe/search) module. It is a wrapper for [Whoosh](https://pypi.org/project/Whoosh/) a full text search library written in Python.
 
-You can extend the `FullTextSearch` class to create a search class for a specific requirement. For example the [`WebsiteSearch`](https://github.com/frappe/frappe/blob/develop/frappe/search/website_search) is a wrapper for indexing public facing web pages and exposing a search.
+You can extend the `FullTextSearch` class to create a search class for a specific requirement. For example the [`WebsiteSearch`](https://github.com/frappe/frappe/blob/develop/frappe/search/website_search.py) is a wrapper for indexing public facing web pages and exposing a search.
 
 ## The `FullTextSearch` class
 

--- a/frappe_docs/www/docs/user/en/translations.md
+++ b/frappe_docs/www/docs/user/en/translations.md
@@ -249,9 +249,8 @@ $ bench --site sitename get-untranslated [lang] [path-to-file]
 #### Step 2: Translate
 
 Create another file with updated translations (in the same order as the source
-file). For this you can use the [Google Translator
-Toolkit](https://translate.google.com/toolkit) or [Bing
-Translator](http://www.bing.com/translator/).
+file). For this you can use the [Google Translator](https://translate.google.com/) or
+[Bing Translator](http://www.bing.com/translator/).
 
 #### Step 3: Import your translations
 

--- a/frappe_docs/www/docs/user/en/tutorial/types-of-doctype.md
+++ b/frappe_docs/www/docs/user/en/tutorial/types-of-doctype.md
@@ -136,7 +136,7 @@ class LibraryTransaction(Document):
             self.validate_issue()
             # set the article status to be Issued
             article = frappe.get_doc("Article", self.article)
-            article.status == "Issued"
+            article.status = "Issued"
             article.save()
 
         elif self.type == "Return":


### PR DESCRIPTION
Summary of changes:
- remove default mariadb configs for Arch linux installation guide: 
	Removed config are now default in mariadb, Ref: https://mariadb.com/kb/en/innodb-system-variables/
- add mysql charset config in mac install. 
	This was recommended in other installation guides on frappe/bench wiki.
- fix broken link to apps section
- fix link for frequent commands
- fix broken link to WebsiteSearch.py file
- Desktop is now Workspace, changed link and text: 
	Refer commit 36cbbf2d and discussion on erpnext forums: https://discuss.erpnext.com/t/redesigning-desk/59105
- fix link to easy install script
- Remove google translate toolkit and linking to homepage: 
	Google translate toolkit was shutdown last year. Ref:  https://support.google.com/answer/9464390
- Update homebrew install command.
	Old ruby based installer is now replaced with shell script
- Fix virtualbox install typo.
- Fix broken link to controllers list
- fix double-equals typo