### PR TITLE
docs: document frappe.new_doc()

### DIFF
--- a/frappe_docs/www/docs/user/en/api/dialog.md
+++ b/frappe_docs/www/docs/user/en/api/dialog.md
@@ -203,6 +203,64 @@ frappe.show_progress('Loading..', 70, 100, 'Please wait');
 ![Show Progress](/docs/assets/img/api/dialog-api-progress.png)
 *frappe.show_progress*
 
+### frappe.new_doc
+`frappe.new_doc(doctype, route_options, init_callback)`
+
+Creates a (draft) new document of the specified `doctype` and switches
+to a form for editing it. If the `doctype` has a defined default "Quick
+Entry" form (that allows for specifying a few most important fields
+when creating a new document of this type) the form used will be that
+Quick Entry form; otherwise, it will be the usual document entry/edit
+form, showing the new document.
+
+Often when you are creating a new document in the user interface you
+want to initialize some of its fields based on the user interaction
+that triggered the creation. The other two arguments can be used for
+such initialization.
+
+Specifically, the `route_options` argument is a quick, convenient way to
+set any fields of type Link, Select, Data, or Dynamic Link in the new
+document. Its value should be an object whose keys are the desired
+field names and whose values are the initial values. If it is undefined,
+nothing is set.
+
+If you need to do any other initialization of the new document that
+is not possible with `route_options`, `init_callback`
+gives you full control. It should be a function of one argument. If
+the doctype is initialized with a Quick Entry form, the callback is
+called with the Quick Entry dialog object just before control is
+released back to the user. Otherwise, the callback is called with the
+new document just before the user is allowed to edit it in the standard
+form.
+
+Thus, for example, you can create a new Task for the user to edit via:
+```js
+frappe.new_doc("Task", {subject: "New Task"},
+               doc => {doc.description = "Do what's necessary";});
+```
+
+Note that "subject" is a field of type Data in a Task, so we are able
+to take advantage of the `route_options` argument to set it; but
+"description" is of type Text Editor, so if we want to initialize it,
+that must be done in the callback.
+
+For a slightly more complex example, here's a call that creates a new
+Journal Entry of type Bank Entry and populates one side of the
+transaction:
+```js
+frappe.new_doc("Journal Entry", {"voucher_type": "Bank Entry"}, doc => {
+    doc.posting_date = date;
+    let newacc = frappe.model.add_child(doc, "accounts");
+    newacc.account = account;
+    newacc.account_currency = currency;
+    newacc.debit_in_account_currency = credit;
+    newacc.credit_in_account_currency = debit;
+}
+```
+
+(here presumably date, account, currency, credit, and debit are local
+variables with the desired values for the new Journal Entry).
+
 ### frappe.ui.form.MultiSelectDialog
 `new frappe.ui.form.MultiSelectDialog({ doctype, target, setters, date_field, get_query, action })`
 

--- a/frappe_docs/www/docs/user/en/api/dialog.md
+++ b/frappe_docs/www/docs/user/en/api/dialog.md
@@ -206,60 +206,62 @@ frappe.show_progress('Loading..', 70, 100, 'Please wait');
 ### frappe.new_doc
 `frappe.new_doc(doctype, route_options, init_callback)`
 
-Creates a (draft) new document of the specified `doctype` and switches
-to a form for editing it. If the `doctype` has a defined default "Quick
-Entry" form (that allows for specifying a few most important fields
-when creating a new document of this type) the form used will be that
-Quick Entry form; otherwise, it will be the usual document entry/edit
-form, showing the new document.
+Opens a new form of the specified DocType that allows to edit and save it. If
+"Quick Entry" is enabled for the DocType (that allows to enter the most
+important fields) the "Quick Entry" pop-up window will be shown. Otherwise you
+will be redirected to the usual document entry form.
 
-Often when you are creating a new document in the user interface you
-want to initialize some of its fields based on the user interaction
-that triggered the creation. The other two arguments can be used for
-such initialization.
+For example, let's create a new **Task**:
 
-Specifically, the `route_options` argument is a quick, convenient way to
-set any fields of type Link, Select, Data, or Dynamic Link in the new
-document. Its value should be an object whose keys are the desired
-field names and whose values are the initial values. If it is undefined,
-nothing is set.
+```js
+frappe.new_doc("Task");
+```
 
-If you need to do any other initialization of the new document that
-is not possible with `route_options`, `init_callback`
-gives you full control. It should be a function of one argument. If
-the doctype is initialized with a Quick Entry form, the callback is
-called with the Quick Entry dialog object just before control is
-released back to the user. Otherwise, the callback is called with the
-new document just before the user is allowed to edit it in the standard
-form.
+Often when you are creating a new document in the user interface you want to
+initialize some of its fields based on the user interaction that triggered the
+creation. The other two arguments can be used for such initialization.
 
-Thus, for example, you can create a new Task for the user to edit via:
+Specifically, the `route_options` argument is a quick and convenient way to set
+any field of type Link, Select, Data, or Dynamic Link in the new document. Its
+value should be an object whose keys are the desired field names and whose
+values are the initial values.
+
+```js
+frappe.new_doc("Task", {subject: "New Task"});
+```
+
+If you need to do any other initialization of the new document that is not
+possible with `route_options`, `init_callback` gives you full control. It should
+be a function of one argument. If the doctype is initialized with a
+"Quick Entry" form, the callback is called with the "Quick Entry" dialog object
+just before control is released back to the user. Otherwise, the callback is
+called with the new document just before the user is allowed to edit it in the
+standard form.
+
 ```js
 frappe.new_doc("Task", {subject: "New Task"},
-               doc => {doc.description = "Do what's necessary";});
+				doc => {doc.description = "Do what's necessary";});
 ```
 
-Note that "subject" is a field of type Data in a Task, so we are able
-to take advantage of the `route_options` argument to set it; but
-"description" is of type Text Editor, so if we want to initialize it,
-that must be done in the callback.
+Note that `subject` is a field of type "Data", so we are able to take advantage
+of the `route_options` argument to set it. `description` is a field of type
+"Text Editor", so if we want to initialize it, that must be done in the
+callback.
 
 For a slightly more complex example, here's a call that creates a new
-Journal Entry of type Bank Entry and populates one side of the
+**Journal Entry** of type "Bank Entry" and populates one side of the
 transaction:
+
 ```js
 frappe.new_doc("Journal Entry", {"voucher_type": "Bank Entry"}, doc => {
-    doc.posting_date = date;
-    let newacc = frappe.model.add_child(doc, "accounts");
-    newacc.account = account;
-    newacc.account_currency = currency;
-    newacc.debit_in_account_currency = credit;
-    newacc.credit_in_account_currency = debit;
-}
+	doc.posting_date = frappe.datetime.get_today();
+	let row = frappe.model.add_child(doc, "accounts");
+	row.account = 'Bank - A';
+	row.account_currency = 'USD';
+	row.debit_in_account_currency = 100.0;
+	row.credit_in_account_currency = 0.0;
+});
 ```
-
-(here presumably date, account, currency, credit, and debit are local
-variables with the desired values for the new Journal Entry).
 
 ### frappe.ui.form.MultiSelectDialog
 `new frappe.ui.form.MultiSelectDialog({ doctype, target, setters, date_field, get_query, action })`


### PR DESCRIPTION
  As requested by barredterra in the discussion to this frappe issue:
  https://github.com/frappe/frappe/issues/7638

  I put the documentation for this on the Dialog API page because it
  seemed to me that in the context of its use in client-side code,
  frappe.new_doc() does primarily serve as a means of creating a
  user dialog, specifically for the creation of a new document.

Docs for https://github.com/frappe/frappe/pull/11900