### PR TITLE
replacing clear_custom_button to remove_custom_button

### DIFF
--- a/frappe_docs/www/docs/user/en/api/form.md
+++ b/frappe_docs/www/docs/user/en/api/form.md
@@ -289,16 +289,16 @@ frm.add_custom_button('Closed', () => {
 }, 'Set Status');
 ```
 
-### frm.clear\_custom_button
+### frm.remove\_custom_button
 
 Remove a specific custom button by label (and group).
 
 ```js
 // remove custom button
-frm.clear_custom_button('Open Reference form');
+frm.remove_custom_button('Open Reference form');
 
 // remove custom button in a group
-frm.clear_custom_button('Closed', 'Set Status');
+frm.remove_custom_button('Closed', 'Set Status');
 ```
 
 ### frm.clear\_custom_buttons


### PR DESCRIPTION
Issue - didn't found the function clear_custom_button 
![image](https://user-images.githubusercontent.com/20715976/105978731-e197c100-60b8-11eb-880e-90f9e8bb4477.png)
