### PR TITLE
fix: remove whitespace from jinja examples

### DIFF
--- a/frappe_docs/www/docs/user/en/portal-pages.md
+++ b/frappe_docs/www/docs/user/en/portal-pages.md
@@ -82,7 +82,7 @@ Here is what a sample page might look like:
 {% raw %}
 ```html
 <!-- about.html -->
-{%  extends "templates/web.html" %}
+{% extends "templates/web.html" %}
 
 {% block title %}{{ _("About Us") }}{% endblock %}
 

--- a/frappe_docs/www/docs/user/en/tutorial/portal-pages.md
+++ b/frappe_docs/www/docs/user/en/tutorial/portal-pages.md
@@ -41,7 +41,7 @@ the following HTML to **article.html**.
 
 {% raw %}
 ```html
-{%  extends "templates/web.html" %}
+{% extends "templates/web.html" %}
 
 {% block page_content %}
 <div class="py-20 row">


### PR DESCRIPTION
Minor fix.  New users who are copy pasting code could run into problems as currently extra whitespace isn't handled well by router. 

should not be merged till frappe/frappe#12314 is fixed.