### PR TITLE
docs: update doc for --frappe-branch flag

### DIFF
--- a/frappe_docs/www/docs/user/en/bench/resources/bench-commands-cheatsheet.md
+++ b/frappe_docs/www/docs/user/en/bench/resources/bench-commands-cheatsheet.md
@@ -13,7 +13,7 @@
   * `--ignore-exist`                  Ignore if Bench instance exists.
   * `--apps_path TEXT`                path to json files with apps to install after init
   * `--frappe-path TEXT`              path to frappe repo
-  * `--frappe-branch TEXT`            path to frappe repo
+  * `--frappe-branch TEXT`            Clone a particular branch of frappe
   * `--clone-from TEXT`               copy repos from path
   * `--clone-without-update`          copy repos from path without update
   * `--no-procfile`                   Pull changes in all the apps in bench


### PR DESCRIPTION
Previous help message was misleading.  

Ref: https://github.com/frappe/bench/pull/1116 