### PR TITLE
docs: Update MariaDB installation instructions for Ubuntu

### DIFF
--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -117,8 +117,18 @@ apt install git python-dev redis-server
 
 ```bash
 apt-get install software-properties-common
+```
+
+If you are on Ubuntu version older than 20.04, run this before installing MariaDB:
+
+```
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
 add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.ubuntu-tw.org/mirror/mariadb/repo/10.3/ubuntu xenial main'
+```
+
+If you are on version Ubuntu 20.04, then MariaDB is available in default repo and you can directly run the below commands to install it:
+
+```
 apt-get update
 apt-get install mariadb-server-10.3
 ```
@@ -274,4 +284,3 @@ bench start
 ```
 
 Congratulations, you have installed bench on to your system.
-

--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -121,14 +121,14 @@ apt-get install software-properties-common
 
 If you are on Ubuntu version older than 20.04, run this before installing MariaDB:
 
-```
+```bash
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
 add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.ubuntu-tw.org/mirror/mariadb/repo/10.3/ubuntu xenial main'
 ```
 
 If you are on version Ubuntu 20.04, then MariaDB is available in default repo and you can directly run the below commands to install it:
 
-```
+```bash
 apt-get update
 apt-get install mariadb-server-10.3
 ```


### PR DESCRIPTION
Fixes #97 

The default Ubuntu 20.04 repository includes MariaDB 10.3 package (which is required by Frappe while) while Ubuntu 18.04's default repository has MariaDB 10.1. So, the external PPA should not be added in Ubuntu 20.04. 

If the external PPA repository is added to Ubuntu 20.04 system, it causes conflicting issues while MariaDB installation.