### PR TITLE
fix: broken report links

### DIFF
--- a/frappe_docs/www/docs/_sidebar.json
+++ b/frappe_docs/www/docs/_sidebar.json
@@ -61,7 +61,7 @@
 			{ "title": "Form", "route": "/docs/user/en/api/form" },
 			{ "title": "Controls", "route": "/docs/user/en/api/controls" },
 			{ "title": "List", "route": "/docs/user/en/api/list" },
-			{ "title": "Page", "route": "/docs/user/en/api/server-calls" },
+			{ "title": "Page", "route": "/docs/user/en/api/page" },
 			{ "title": "Common Utilities", "route": "/docs/user/en/api/js-utils" },
 			{ "title": "Dialog API", "route": "/docs/user/en/api/dialog" }
 		]

--- a/frappe_docs/www/docs/user/en/desk/reports/index.md
+++ b/frappe_docs/www/docs/user/en/desk/reports/index.md
@@ -16,9 +16,9 @@ reports depending on their complexity.
 
 Let's discuss each type and how to build them using Frappe.
 
-1. [Report Builder](/docs/user/en/desk/report-builder): Simple reports that are built from the Desk user interface.
-1. [Query Report](/docs/user/en/desk/query-report): Write Reports using SQL query
-1. [Script Report](/docs/user/en/desk/script-report): Write Reports using scripts
+1. [Report Builder](/docs/user/en/desk/reports/report-builder): Simple reports that are built from the Desk user interface.
+1. [Query Report](/docs/user/en/desk/reports/query-report): Write Reports using SQL query
+1. [Script Report](/docs/user/en/desk/reports/script-report): Write Reports using scripts
 
 ## Query Report View
 


### PR DESCRIPTION
Fix the links for query, script, and report builder pages.

Fixes #110 