### PR TITLE
fix(scripting): broken link for script-report

### DIFF
--- a/frappe_docs/www/docs/user/en/desk/scripting/index.md
+++ b/frappe_docs/www/docs/user/en/desk/scripting/index.md
@@ -15,5 +15,5 @@ Different ways of Scripting:
 
 1. [Client Script](/docs/user/en/desk/scripting/client-script)
 1. [Server Script](/docs/user/en/desk/scripting/server-script)
-1. [Script Report](/docs/user/en/desk/script-report)
+1. [Script Report](/docs/user/en/desk/reports/script-report)
 1. [System Console](/docs/user/en/desk/scripting/system-console)


### PR DESCRIPTION
Fixes the broken `Script Report` link on Scripting page https://frappeframework.com/docs/user/en/desk/scripting.
Reported in https://github.com/frappe/frappe_docs/issues/110
![image](https://user-images.githubusercontent.com/37302950/113900321-525f0600-97eb-11eb-8b3a-9a9c73ece1ac.png)

![image](https://user-images.githubusercontent.com/37302950/113900274-483d0780-97eb-11eb-8b0d-20b1c95710fe.png)
