### PR TITLE
chore: Remove deleted command's docs

### DIFF
--- a/frappe_docs/www/docs/user/en/bench/bench-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/bench-commands.md
@@ -120,7 +120,7 @@ each with `bench` in your shell. Therefore, the usage for these commands is as
  - **set-redis-cache-host**: Set Redis cache host for bench
  - **set-redis-queue-host**: Set Redis queue host for bench
  - **set-redis-socketio-host**: Set Redis socketio host for bench
- - **set-default-site**: Set default site for bench
+ - **use**: Set default site for bench
  - **download-translations**: Download latest translations
 
 #### Development


### PR DESCRIPTION
For PR: https://github.com/frappe/bench/pull/1161

The `set-default-site` command is being removed from the `bench`.

The `bench use <site>` command should be used for setting the default site.