### PR TITLE
fix: hooks.md

### DIFF
--- a/frappe_docs/www/docs/user/en/python-api/hooks.md
+++ b/frappe_docs/www/docs/user/en/python-api/hooks.md
@@ -821,7 +821,7 @@ frappe.ui.form.on('Todo', {
 });
 ```
 
-> The events/functions defined in `app/public/todo.js` will override
+> The events/functions defined in `app/public/todo.js` will extend
 > those in the standard form script of `ToDo` doctype.
 
 ### CRUD Events


### PR DESCRIPTION
I've tried the `doctype_js` hook and it seems the description is wrong here. Both scripts resp. the same function in both scripts were executed.