### PR TITLE
docs: Common Python Utility Functions

### DIFF
--- a/frappe_docs/www/docs/_sidebar.json
+++ b/frappe_docs/www/docs/_sidebar.json
@@ -46,6 +46,7 @@
 			{ "title": "Document", "route": "/docs/user/en/api/document" },
 			{ "title": "Database", "route": "/docs/user/en/api/database" },
 			{ "title": "Jinja", "route": "/docs/user/en/api/jinja" },
+			{ "title": "Utils", "route": "/docs/user/en/api/utils" },
 			{ "title": "Router", "route": "/docs/user/en/python-api/router" },
 			{ "title": "Response", "route": "/docs/user/en/python-api/response" },
 			{ "title": "Search", "route": "/docs/user/en/python-api/search" },

--- a/frappe_docs/www/docs/_sidebar.json
+++ b/frappe_docs/www/docs/_sidebar.json
@@ -46,7 +46,7 @@
 			{ "title": "Document", "route": "/docs/user/en/api/document" },
 			{ "title": "Database", "route": "/docs/user/en/api/database" },
 			{ "title": "Jinja", "route": "/docs/user/en/api/jinja" },
-			{ "title": "Utils", "route": "/docs/user/en/api/utils" },
+			{ "title": "Common Utilities", "route": "/docs/user/en/api/utils" },
 			{ "title": "Router", "route": "/docs/user/en/python-api/router" },
 			{ "title": "Response", "route": "/docs/user/en/python-api/response" },
 			{ "title": "Search", "route": "/docs/user/en/python-api/search" },

--- a/frappe_docs/www/docs/user/en/api/index.md
+++ b/frappe_docs/www/docs/user/en/api/index.md
@@ -14,8 +14,16 @@ the most used methods and utilities in the `frappe` namespace itself. It's the
 only import you need (most of the time) in a Python file.
 
 1. [Document](/docs/user/en/api/document)
-1. [Database](/docs/user/en/api/database)
-
+2. [Database](/docs/user/en/api/database)
+3. [Jinja](/docs/user/en/api/jinja)
+4. [Common Utilities](/docs/user/en/api/utils)
+5. [Router](/docs/user/en/python-api/router)
+6. [Response](/docs/user/en/python-api/response)
+7. [Search](/docs/user/en/python-api/search)
+8. [Hooks](/docs/user/en/python-api/hooks)
+9. [REST API](/docs/user/en/api/rest)
+10. [Full Text Search](/docs/user/en/api/full-text-search)
+11. [Dialog API](/docs/user/en/api/py-dialog)
 
 ## Javascript
 
@@ -25,11 +33,11 @@ are only available inside the Desk. A good way to explore these APIs is from the
 browser console.
 
 1. [Form](/docs/user/en/api/form)
-1. [Controls](/docs/user/en/api/controls)
-1. [Page](/docs/user/en/api/page)
-1. [Server Calls (AJAX)](/docs/user/en/api/server-calls)
-1. [Common Utilities](/docs/user/en/api/js-utils)
-1. [Dialog API](/docs/user/en/api/dialog)
+2. [Controls](/docs/user/en/api/controls)
+3. [Page](/docs/user/en/api/page)
+4. [Server Calls (AJAX)](/docs/user/en/api/server-calls)
+5. [Common Utilities](/docs/user/en/api/js-utils)
+6. [Dialog API](/docs/user/en/api/dialog)
 
 ## Other
 

--- a/frappe_docs/www/docs/user/en/api/index.md
+++ b/frappe_docs/www/docs/user/en/api/index.md
@@ -14,16 +14,16 @@ the most used methods and utilities in the `frappe` namespace itself. It's the
 only import you need (most of the time) in a Python file.
 
 1. [Document](/docs/user/en/api/document)
-2. [Database](/docs/user/en/api/database)
-3. [Jinja](/docs/user/en/api/jinja)
-4. [Common Utilities](/docs/user/en/api/utils)
-5. [Router](/docs/user/en/python-api/router)
-6. [Response](/docs/user/en/python-api/response)
-7. [Search](/docs/user/en/python-api/search)
-8. [Hooks](/docs/user/en/python-api/hooks)
-9. [REST API](/docs/user/en/api/rest)
-10. [Full Text Search](/docs/user/en/api/full-text-search)
-11. [Dialog API](/docs/user/en/api/py-dialog)
+1. [Database](/docs/user/en/api/database)
+1. [Jinja](/docs/user/en/api/jinja)
+1. [Common Utilities](/docs/user/en/api/utils)
+1. [Router](/docs/user/en/python-api/router)
+1. [Response](/docs/user/en/python-api/response)
+1. [Search](/docs/user/en/python-api/search)
+1. [Hooks](/docs/user/en/python-api/hooks)
+1. [REST API](/docs/user/en/api/rest)
+1. [Full Text Search](/docs/user/en/api/full-text-search)
+1. [Dialog API](/docs/user/en/api/py-dialog)
 
 ## Javascript
 
@@ -33,11 +33,11 @@ are only available inside the Desk. A good way to explore these APIs is from the
 browser console.
 
 1. [Form](/docs/user/en/api/form)
-2. [Controls](/docs/user/en/api/controls)
-3. [Page](/docs/user/en/api/page)
-4. [Server Calls (AJAX)](/docs/user/en/api/server-calls)
-5. [Common Utilities](/docs/user/en/api/js-utils)
-6. [Dialog API](/docs/user/en/api/dialog)
+1. [Controls](/docs/user/en/api/controls)
+1. [Page](/docs/user/en/api/page)
+1. [Server Calls (AJAX)](/docs/user/en/api/server-calls)
+1. [Common Utilities](/docs/user/en/api/js-utils)
+1. [Dialog API](/docs/user/en/api/dialog)
 
 ## Other
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -348,4 +348,19 @@ validate_phone_number('87345%%', throw=True) # InvalidPhoneNumberError
 
 ## frappe.cache()
 
+Function Signature: `cache()`
+
+Returns the redis connection, which is an instance of class `RedisWrapper` which is inherited from the `redis.Redis` class. You can use this connection to use the Redis cache to store/retrieve key-value pairs.
+
+Example Usage:
+
+```py
+import frappe
+
+cache = frappe.cache()
+
+cache.set('name', 'frappe') # True
+cache.get('name') # b'frappe'
+```
+
 ## frappe.sendmail()

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -83,7 +83,23 @@ format_duration(1000000) # '11d 13h 46m 40s'
 format_duration(1000000, hide_days=True) # '277h 46m 40s'
 ```
 
-## comma_and and comma_or
+## comma_and
+
+Function Signature: `comma_and(some_list, add_quotes=True)`
+
+Given a list or tuple `some_list`, returns a string of the format `1st item, 2nd item, .... and last item`. This function uses `frappe._`, so you don't have to worry about the translations for the word `and`. If `add_quotes` is `False`, returns the items without quotes, with quotes otherwise. If the type of `some_list` passed as an argument is something other than a list or tuple, it (`some_list`) is returned as it is.
+
+Example Usage:
+
+```py
+from frappe.utils import comma_and
+
+comma_and([1, 2, 3]) # "'1', '2' and '3'"
+comma_and(['Apple', 'Ball', 'Cat'], add_quotes=False) # 'Apple, Ball and Cat'
+comma_and('abcd') # 'abcd'
+```
+
+> There is also a `comma_or` function which is similar to `comma_and` except the separator, which is `or` in the case of `comma_or`.
 
 ## money_in_words
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -364,3 +364,60 @@ cache.get('name') # b'frappe'
 ```
 
 ## frappe.sendmail()
+
+Function Signature: `def sendmail(recipients=[], sender="", subject="No Subject", message="No Message", as_markdown=False, template=None, args=None, **kwargs)`
+
+`recipients`: List of recipients
+`sender`: Email sender. Default is current user or default outgoing account
+`subject`: Email Subject
+`message`: (or `content`) Email Content
+`as_markdown`: Convert content markdown to HTML
+`template`: Name of html template (jinja) from templates/emails folder
+`args`: Arguments for rendering the template
+
+For most cases, the above arguments are sufficient but there are many other keyword arguments that can be passed to this function. To see all the keyword arguments, please have a look at this functions implementation (`frappe/__init__.py`).
+
+This function can be used to send email using user's default **Email Account** or global default **Email Account**.
+
+Example Usage:
+
+```py
+import frappe
+
+recipients = [
+	'gavin@erpnext.com',
+	'hussain@erpnext.com'
+]
+
+frappe.sendmail(
+	recipients=recipients,
+	subject=frappe._("Birthday Reminder"),
+	template="birthday_reminder",
+	args=dict(
+		reminder_text=reminder_text,
+		birthday_persons=birthday_persons,
+		message=message,
+	),
+	header=_("Birthday Reminder 🎂")
+)
+```
+
+Sample Jinja template file:
+
+```html
+<!-- templates/emails/birthday_reminder.html -->
+<div>
+<div class="gray-container text-center">
+	<div>
+		{% for person in birthday_persons %}
+			{% if person.image  %}
+				<img src="{{ person.image }}" title="{{ person.name }}">
+			{% endif %}
+		{% endfor %}
+	</div>
+  <div style="margin-top: 15px">
+    <span>{{ reminder_text }}</span>
+    <p class="text-muted">{{ message }}</p>
+  </div>
+</div>
+```

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -40,6 +40,22 @@ pretty_date(now()) # 'just now'
 
 ## format_duration
 
+Function Signature: `format_duration(seconds, hide_days=False)`
+
+Converts the given duration value in seconds (float) to duration format.
+
+Example Usage:
+```py
+from frappe.utils import format_duration
+
+format_duration(50) # '50s'
+format_duration(10000) # '2h 46m 40s'
+format_duration(1000000) # '11d 13h 46m 40s'
+
+# Convert days to hours
+format_duration(1000000, hide_days=True) # '277h 46m 40s'
+```
+
 ## comma_and and comma_or
 
 ## money_in_words

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -13,7 +13,30 @@ There are many different **utility functions** available in Frappe Framework tha
 
 This utility methods (`utils`) can be imported from the `frappe` module (or nested modules like `frappe.utils` and `frappe.utils.data`) in any Python file of your Frappe app. This list is not at all exhaustive, you can take a peek at the Framework codebase to see what's available.
 
+## now, getdate, today
+
+## add_to_date
+
 ## pretty_date
+
+Function Signature: `pretty_date(iso_datetime)`
+
+Takes an ISO time and returns a string representing how long ago the date represents. Very common in communication applications like instant messangers.
+
+Example usage:
+
+```py
+from frappe.utils import pretty_date, now, add_to_date
+
+pretty_date(now()) # 'just now'
+
+# Some example outputs:
+
+# 1 hour ago
+# 20 minutes ago
+# 1 week ago
+# 5 years ago
+```
 
 ## format_duration
 
@@ -22,8 +45,6 @@ This utility methods (`utils`) can be imported from the `frappe` module (or nest
 ## money_in_words
 
 ## validate_json_string
-
-## getdate, today
 
 ## random_string
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -42,7 +42,20 @@ getdate() # datetime.date(2021, 5, 25)
 getdate('2000-03-18') # datetime.date(2000, 3, 18)
 ```
 
-## today
+## nowdate and today
+
+Function Signature: `nowdate()`
+
+Returns current date in the format 'yyyy-mm-dd'. `today()` is an alias to `nowdate()`.
+
+Example Usage:
+
+```py
+from frappe.utils import today, nowdate
+
+today() # '2021-05-25'
+nowdate() # '2021-05-25'
+```
 
 ## add_to_date
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -90,7 +90,7 @@ add_to_date(None, years=6) # datetime.datetime(2027, 5, 21, 15, 32, 31, 652089)
 
 Function Signature: `pretty_date(iso_datetime)`
 
-Takes an ISO time and returns a string representing how long ago the date represents. Very common in communication applications like instant messangers.
+Takes an ISO time and returns a string representing how long ago the date represents. Very common in communication applications like instant messengers.
 
 Example usage:
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -326,7 +326,25 @@ validate_email_address(
 validate_email_address('some other text') # ''
 ```
 
-## validate_phone
+## validate_phone_number
+
+Function Signature: `validate_phone_number(phone_number, throw=False)`
+
+Returns `True` if `phone_number` (string) is a valid phone number. If `phone_number` is invalid and `throw` is `True`, `frappe.InvalidPhoneNumberError` is thrown.
+
+Example Usage:
+
+```py
+from frappe.utils import validate_phone_number
+
+# Valid phone numbers
+validate_phone_number('753858375') # True
+validate_phone_number('+91-75385837') # True
+
+# Invalid phone numbers
+validate_phone_number('invalid') # False
+validate_phone_number('87345%%', throw=True) # InvalidPhoneNumberError
+```
 
 ## frappe.cache()
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -8,9 +8,9 @@ metatags:
 
 # Utility Functions
 
-There are many different **utility functions** available in Frappe Framework that you can use to carry out many common operations like date formating, PDF generation and much more.
+Frappe Framework comes with various utility functions to handle common operations for managing site-specific DateTime management, date and currency formatting, PDF generation, and much more.
 
-This utility methods (`utils`) can be imported from the `frappe` module (or nested modules like `frappe.utils` and `frappe.utils.data`) in any Python file of your Frappe app. This list is not at all exhaustive, you can take a peek at the Framework codebase to see what's available.
+These utility methods can be imported from the `frappe.utils` module (and its nested modules like `frappe.utils.logger` and `frappe.utils.data`) in any Python file of your Frappe App. This list is not at all exhaustive, you can take a peek at the Framework codebase to see what's available.
 
 ## now
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -60,6 +60,26 @@ format_duration(1000000, hide_days=True) # '277h 46m 40s'
 
 ## money_in_words
 
+Function Signature: `money_in_words(number, main_currency=None, fraction_currency=None)`
+
+`number`: A floating point money amount
+
+`main_currency`: Uses this as the main currency. If not given, tries to fetch from default settings or uses `INR` if not found there.
+
+This function returns string in words with currency and fraction currency.
+
+Example Usage:
+
+```py
+from frappe.utils import money_in_words
+
+money_in_words(900) # 'INR Nine Hundred and Fifty Paisa only.'
+money_in_words(900.50) # 'INR Nine Hundred and Fifty Paisa only.'
+money_in_words(900.50, "USD") # 'USD Nine Hundred and Fifty Centavo only.'
+money_in_words(900.50, "USD", "Cents") # 'USD Nine Hundred and Fifty Cents only.'
+
+```
+
 ## validate_json_string
 
 ## random_string

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -160,8 +160,8 @@ from frappe.utils import money_in_words
 
 money_in_words(900) # 'INR Nine Hundred and Fifty Paisa only.'
 money_in_words(900.50) # 'INR Nine Hundred and Fifty Paisa only.'
-money_in_words(900.50, "USD") # 'USD Nine Hundred and Fifty Centavo only.'
-money_in_words(900.50, "USD", "Cents") # 'USD Nine Hundred and Fifty Cents only.'
+money_in_words(900.50, 'USD') # 'USD Nine Hundred and Fifty Centavo only.'
+money_in_words(900.50, 'USD', 'Cents') # 'USD Nine Hundred and Fifty Cents only.'
 
 ```
 
@@ -250,18 +250,18 @@ def generate_invoice():
 		'iPhone 13': 80
 	}]
 
-	html = "<h1>Invoice from Star Electronics e-Store!</h1>"
+	html = '<h1>Invoice from Star Electronics e-Store!</h1>'
 
 	# Add items to PDF HTML
-	html += "<ol>"
+	html += '<ol>'
 	for item, qty in cart.items():
-		html += f"<li>{item} - {qty}</li>"
-	html += "</ol>"
+		html += f'<li>{item} - {qty}</li>'
+	html += '</ol>'
 
 	# Attaching PDF to response
-	frappe.local.response.filename = "invoice.pdf"
+	frappe.local.response.filename = 'invoice.pdf'
 	frappe.local.response.filecontent = get_pdf(html)
-	frappe.local.response.type = "pdf"
+	frappe.local.response.type = 'pdf'
 ```
 
 ## get_abbr
@@ -391,14 +391,14 @@ recipients = [
 
 frappe.sendmail(
 	recipients=recipients,
-	subject=frappe._("Birthday Reminder"),
-	template="birthday_reminder",
+	subject=frappe._('Birthday Reminder'),
+	template='birthday_reminder',
 	args=dict(
 		reminder_text=reminder_text,
 		birthday_persons=birthday_persons,
 		message=message,
 	),
-	header=_("Birthday Reminder 🎂")
+	header=_('Birthday Reminder 🎂')
 )
 ```
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -1,0 +1,41 @@
+---
+add_breadcrumbs: 1
+title: Utils
+image: /assets/frappe_io/images/frappe-framework-logo-with-padding.png
+metatags:
+ description: >
+  Utility functions available in Frappe Framework
+---
+
+# Utility Functions
+
+There are many different **utility functions** available in Frappe Framework that you can use to carry out many common operations like date formating, PDF generation and much more. 
+
+This utility methods (`utils`) can be imported from the `frappe` module (or nested modules like `frappe.utils` and `frappe.utils.data`) in any Python file of your Frappe app. This list is not at all exhaustive, you can take a peek at the Framework codebase to see what's available.
+
+## pretty_date
+
+## format_duration
+
+## comma_and and comma_or
+
+## money_in_words
+
+## validate_json_string
+
+## getdate, today
+
+## random_string
+
+## unique
+
+## get_pdf
+
+## validate_url
+
+## validate_email_address and validate_phone
+
+## frappe.cache()
+
+## frappe.sendmail()
+

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -13,7 +13,23 @@ There are many different **utility functions** available in Frappe Framework tha
 
 This utility methods (`utils`) can be imported from the `frappe` module (or nested modules like `frappe.utils` and `frappe.utils.data`) in any Python file of your Frappe app. This list is not at all exhaustive, you can take a peek at the Framework codebase to see what's available.
 
-## now, getdate, today
+## now
+
+Function Signatures: `now()`
+
+Returns the current datetime in the format 'yyyy-mm-dd hh:mm:ss'
+
+Example Usage:
+
+```py
+from frappe.utils import now
+
+now() # '2021-05-25 06:38:52.242515'
+```
+
+## getdate
+
+## today
 
 ## add_to_date
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -84,6 +84,21 @@ money_in_words(900.50, "USD", "Cents") # 'USD Nine Hundred and Fifty Cents only.
 
 ## random_string
 
+Function Signature: `random_string(length)`
+
+This function generates a random string containing `length` number of characters. This can be useful for cryptographic or secret generation for some cases.
+
+Example Usage:
+
+```py
+from frappe.utils import random_string
+
+random_string(40) # 'mcrLCrlvkUdkaOe8m5xMI8IwDB8lszwJsWtZFveQ'
+random_string(6) # 'htrB4L'
+random_string(6) #'HNRirG'
+
+```
+
 ## unique
 
 ## get_pdf
@@ -124,6 +139,8 @@ def generate_invoice():
 	frappe.local.response.filecontent = get_pdf(html)
 	frappe.local.response.type = "pdf"
 ```
+
+## get_abbr
 
 ## validate_url
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -31,6 +31,40 @@ This utility methods (`utils`) can be imported from the `frappe` module (or nest
 
 ## get_pdf
 
+Function Signature: `get_pdf(html, options=None, output=None)`
+
+`html`: HTML string to render
+
+`options`: An optional `dict` for configuration
+
+`output`: A optional `PdfFileWriter` object.
+
+This function uses `pdfkit` and `pyPDF2` modules to generate PDF files from HTML. If `output` is provided, appends the generated pages to this object and returns it, otherwise returns a `byte` stream of the PDF.
+
+Example usage, generating and returning a PDF as response:
+
+```py
+@frappe.whitelist(allow_guest=True)
+def generate_invoice():
+	cart = [{
+		'Samsung Galaxy S20': 10,
+		'iPhone 13': 80
+	}]
+
+	html = "<h1>Invoice from Star Electronics e-Store!</h1>"
+
+	# Add items to PDF HTML
+	html += "<ol>"
+	for item, qty in cart.items():
+		html += f"<li>{item} - {qty}</li>"
+	html += "</ol>"
+
+	# Attaching PDF to response
+	frappe.local.response.filename = "invoice.pdf"
+	frappe.local.response.filecontent = get_pdf(html)
+	frappe.local.response.type = "pdf"
+```
+
 ## validate_url
 
 ## validate_email_address and validate_phone

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -1,7 +1,6 @@
 ---
 add_breadcrumbs: 1
 title: Common Utility Functions
-image: /assets/frappe_io/images/frappe-framework-logo-with-padding.png
 metatags:
   description: >
     Utility functions available in Frappe Framework
@@ -15,11 +14,11 @@ This utility methods (`utils`) can be imported from the `frappe` module (or nest
 
 ## now
 
-Function Signatures: `now()`
+`now()`
 
 Returns the current datetime in the format 'yyyy-mm-dd hh:mm:ss'
 
-Example Usage:
+
 
 ```py
 from frappe.utils import now
@@ -29,11 +28,11 @@ now() # '2021-05-25 06:38:52.242515'
 
 ## getdate
 
-Function Signature: `getdate(string_date=None)`
+`getdate(string_date=None)`
 
 Converts `string_date` (yyyy-mm-dd) to `datetime.date` object. If no input is provided, current date is returned. Throws an exception if `string_date` is an invalid date string.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import getdate
@@ -44,11 +43,11 @@ getdate('2000-03-18') # datetime.date(2000, 3, 18)
 
 ## nowdate and today
 
-Function Signature: `nowdate()`
+`nowdate()`
 
 Returns current date in the format 'yyyy-mm-dd'. `today()` is an alias to `nowdate()`.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import today, nowdate
@@ -59,7 +58,7 @@ nowdate() # '2021-05-25'
 
 ## add\_to\_date
 
-Function Signature: `add_to_date(date, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0, as_string=False, as_datetime=False)`
+`add_to_date(date, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0, as_string=False, as_datetime=False)`
 
 ```md
 `date`: A string representation or `datetime` object, uses the current `datetime` if `None` is passed
@@ -69,7 +68,7 @@ Function Signature: `add_to_date(date, years=0, months=0, weeks=0, days=0, hours
 
 This function can be quite handy for doing date/datetime deltas, for instance, adding or substracting certain number of days from a particular date/datetime.
 
-Example Usage:
+
 
 ```py
 from datetime import datetime # from python std library
@@ -88,11 +87,11 @@ add_to_date(None, years=6) # datetime.datetime(2027, 5, 21, 15, 32, 31, 652089)
 
 ## pretty_date
 
-Function Signature: `pretty_date(iso_datetime)`
+`pretty_date(iso_datetime)`
 
 Takes an ISO time and returns a string representing how long ago the date represents. Very common in communication applications like instant messengers.
 
-Example usage:
+
 
 ```py
 from frappe.utils import pretty_date, now, add_to_date
@@ -109,11 +108,11 @@ pretty_date(now()) # 'just now'
 
 ## format_duration
 
-Function Signature: `format_duration(seconds, hide_days=False)`
+`format_duration(seconds, hide_days=False)`
 
 Converts the given duration value in seconds (float) to duration format.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import format_duration
@@ -128,11 +127,11 @@ format_duration(1000000, hide_days=True) # '277h 46m 40s'
 
 ## comma_and
 
-Function Signature: `comma_and(some_list, add_quotes=True)`
+`comma_and(some_list, add_quotes=True)`
 
 Given a list or tuple `some_list`, returns a string of the format `1st item, 2nd item, .... and last item`. This function uses `frappe._`, so you don't have to worry about the translations for the word `and`. If `add_quotes` is `False`, returns the items without quotes, with quotes otherwise. If the type of `some_list` passed as an argument is something other than a list or tuple, it (`some_list`) is returned as it is.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import comma_and
@@ -146,7 +145,7 @@ comma_and('abcd') # 'abcd'
 
 ## money\_in\_words
 
-Function Signature: `money_in_words(number, main_currency=None, fraction_currency=None)`
+`money_in_words(number, main_currency=None, fraction_currency=None)`
 
 ```md
 `number`: A floating point money amount
@@ -155,7 +154,7 @@ Function Signature: `money_in_words(number, main_currency=None, fraction_currenc
 
 This function returns string in words with currency and fraction currency.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import money_in_words
@@ -168,11 +167,11 @@ money_in_words(900.50, 'USD', 'Cents') # 'USD Nine Hundred and Fifty Cents only.
 
 ## validate\_json\_string
 
-Function Signature: `validate_json_string(string)`
+`validate_json_string(string)`
 
 Raises `frappe.ValidationError` if the given `string` is a valid JSON (JavaScript Object Notation) string. You can use a `try-except` block to handle a call to this function as shown the code snippet below.
 
-Example Usage:
+
 
 ```py
 import frappe
@@ -192,11 +191,11 @@ except frappe.ValidationError:
 
 ## random_string
 
-Function Signature: `random_string(length)`
+`random_string(length)`
 
 This function generates a random string containing `length` number of characters. This can be useful for cryptographic or secret generation for some cases.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import random_string
@@ -208,13 +207,13 @@ random_string(6) #'HNRirG'
 
 ## unique
 
-Function Signature: `unique(seq)`
+`unique(seq)`
 
 `seq`: An iterable / Sequence
 
 This function returns a list of elements of the given sequence after removing the duplicates. Also, preserves the order, unlike: `list(set(seq))`.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import unique
@@ -226,7 +225,7 @@ unique(('Apple', 'Apple', 'Banana', 'Apple')) # ['Apple', 'Banana']
 
 ## get_pdf
 
-Function Signature: `get_pdf(html, options=None, output=None)`
+`get_pdf(html, options=None, output=None)`
 
 ```md
 `html`: HTML string to render
@@ -236,7 +235,7 @@ Function Signature: `get_pdf(html, options=None, output=None)`
 
 This function uses `pdfkit` and `pyPDF2` modules to generate PDF files from HTML. If `output` is provided, appends the generated pages to this object and returns it, otherwise returns a `byte` stream of the PDF.
 
-Example usage, generating and returning a PDF as response:
+For instance, generating and returning a PDF as response to a web request:
 
 ```py
 import frappe
@@ -265,11 +264,11 @@ def generate_invoice():
 
 ## get_abbr
 
-Function Signature: `get_abbr(string, max_len=2)`
+`get_abbr(string, max_len=2)`
 
 Returns an abbrivated (initials only) version of the given `string` with a maximum of `max_len` letters. It is extensively used in Frappe Framework and ERPNext to generate thumbnail or placeholder images.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import get_abbr
@@ -281,7 +280,7 @@ get_abbr('Mohammad Hussain Nagaria', max_len=3) # 'MHN'
 
 ## validate_url
 
-Function Signature: `validate_url(txt, throw=False, valid_schemes=None)`
+`validate_url(txt, throw=False, valid_schemes=None)`
 
 ```md
 `txt`: A string to check validity
@@ -290,7 +289,7 @@ Function Signature: `validate_url(txt, throw=False, valid_schemes=None)`
 ```
 This utility function can be used to check if a string represents a valid URL address.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import validate_url
@@ -302,11 +301,11 @@ validate_url('https://google.com', throw=True) # throws ValidationError
 
 ## validate\_email\_address
 
-Function Signature: `validate_email_address(email_str, throw=False)`
+`validate_email_address(email_str, throw=False)`
 
 Returns a string containing the email address or comma-separated list of valid email addresses present in the given `email_str`. If `throw` is `True`, `frappe.InvalidEmailAddressError` is thrown in case of no valid email address in present in the given string else an empty string is returned.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import validate_email_address
@@ -326,11 +325,11 @@ validate_email_address('some other text') # ''
 
 ## validate\_phone\_number
 
-Function Signature: `validate_phone_number(phone_number, throw=False)`
+`validate_phone_number(phone_number, throw=False)`
 
 Returns `True` if `phone_number` (string) is a valid phone number. If `phone_number` is invalid and `throw` is `True`, `frappe.InvalidPhoneNumberError` is thrown.
 
-Example Usage:
+
 
 ```py
 from frappe.utils import validate_phone_number
@@ -346,11 +345,11 @@ validate_phone_number('87345%%', throw=True) # InvalidPhoneNumberError
 
 ## frappe.cache()
 
-Function Signature: `cache()`
+`cache()`
 
 Returns the redis connection, which is an instance of class `RedisWrapper` which is inherited from the `redis.Redis` class. You can use this connection to use the Redis cache to store/retrieve key-value pairs.
 
-Example Usage:
+
 
 ```py
 import frappe
@@ -363,7 +362,7 @@ cache.get('name') # b'frappe'
 
 ## frappe.sendmail()
 
-Function Signature: `def sendmail(recipients=[], sender="", subject="No Subject", message="No Message", as_markdown=False, template=None, args=None, **kwargs)`
+`def sendmail(recipients=[], sender="", subject="No Subject", message="No Message", as_markdown=False, template=None, args=None, **kwargs)`
 
 ```md
 `recipients`: List of recipients
@@ -375,11 +374,11 @@ Function Signature: `def sendmail(recipients=[], sender="", subject="No Subject"
 `args`: Arguments for rendering the template
 ```
 
-For most cases, the above arguments are sufficient but there are many other keyword arguments that can be passed to this function. To see all the keyword arguments, please have a look at this functions implementation (`frappe/__init__.py`).
+For most cases, the above arguments are sufficient but there are many other keyword arguments that can be passed to this function. To see all the keyword arguments, please have a look the implementation of this function (`frappe/__init__.py`).
 
 This function can be used to send email using user's default **Email Account** or global default **Email Account**.
 
-Example Usage:
+
 
 ```py
 import frappe

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -302,7 +302,31 @@ validate_url('https://google.com') # True
 validate_url('https://google.com', throw=True) # throws ValidationError
 ```
 
-## validate_email_address and validate_phone
+## validate_email_address
+
+Function Signature: `validate_email_address(email_str, throw=False)`
+
+Returns a string containing the email address or comma-separated list of valid email addresses present in the given `email_str`. If `throw` is `True`, `frappe.InvalidEmailAddressError` is thrown in case of no valid email address in present in the given string else an empty string is returned.
+
+Example Usage:
+
+```py
+from frappe.utils import validate_email_address
+
+# Single valid email address
+validate_email_address('rushabh@erpnext.com') # 'rushabh@erpnext.com'
+validate_email_address('other text, rushabh@erpnext.com, some other text') # 'rushabh@erpnext.com'
+
+# Multiple valid email address
+validate_email_address(
+	'some text, rushabh@erpnext.com, some other text, faris@erpnext.com, yet another no-emailic phrase.'
+) # 'rushabh@erpnext.com, faris@erpnext.com'
+
+# Invalid email address
+validate_email_address('some other text') # ''
+```
+
+## validate_phone
 
 ## frappe.cache()
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -17,6 +17,32 @@ This utility methods (`utils`) can be imported from the `frappe` module (or nest
 
 ## add_to_date
 
+Function Signature: `add_to_date(date, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0, as_string=False, as_datetime=False)`
+
+`date`: A string representation or `datetime` object, uses the current `datetime` if `None` is passed
+`as_string`: Return as string
+`as_datetime`: If `as_string` is True and `as_datetime` is also True, returns a `datetime` string otherwise just the `date` string.
+
+This function can be quite handy for doing date/datetime deltas, for instance, adding or substracting certain number of days from a particular date/datetime.
+
+Example Usage:
+
+```py
+from datetime import datetime # from python std library
+from frappe.utils import add_to_date
+
+today = datetime.now().strftime('%Y-%m-%d')
+print(today) # '2021-05-21'
+
+after_10_days = add_to_date(datetime.now(), days=10, as_string=True)
+print(after_10_days) # '2021-05-31'
+
+add_to_date(datetime.now(), months=2) # datetime.datetime(2021, 7, 21, 15, 31, 18, 119999)
+add_to_date(datetime.now(), days=10, as_string=True, as_datetime=True) # '2021-05-31 15:30:23.757661'
+add_to_date(None, years=6) # datetime.datetime(2027, 5, 21, 15, 32, 31, 652089)
+
+```
+
 ## pretty_date
 
 Function Signature: `pretty_date(iso_datetime)`

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -16,7 +16,7 @@ These utility methods can be imported from the `frappe.utils` module (and its ne
 
 `now()`
 
-Returns the current datetime in the format 'yyyy-mm-dd hh:mm:ss'
+Returns the current datetime in the format **yyyy-mm-dd hh:mm:ss**
 
 ```py
 from frappe.utils import now
@@ -37,17 +37,16 @@ getdate() # datetime.date(2021, 5, 25)
 getdate('2000-03-18') # datetime.date(2000, 3, 18)
 ```
 
-## nowdate and today
+## today
 
-`nowdate()`
+`today()`
 
-Returns current date in the format 'yyyy-mm-dd'. `today()` is an alias to `nowdate()`.
+Returns current date in the format **yyyy-mm-dd**.
 
 ```py
-from frappe.utils import today, nowdate
+from frappe.utils import today
 
 today() # '2021-05-25'
-nowdate() # '2021-05-25'
 ```
 
 ## add\_to\_date
@@ -330,7 +329,7 @@ cache.get('name') # b'frappe'
 
 ## frappe.sendmail()
 
-`def sendmail(recipients=[], sender="", subject="No Subject", message="No Message", as_markdown=False, template=None, args=None, **kwargs)`
+`sendmail(recipients=[], sender="", subject="No Subject", message="No Message", as_markdown=False, template=None, args=None, **kwargs)`
 
 ```md
 `recipients`: List of recipients

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -44,6 +44,9 @@ This function uses `pdfkit` and `pyPDF2` modules to generate PDF files from HTML
 Example usage, generating and returning a PDF as response:
 
 ```py
+import frappe
+from frappe.utils.pdf import get_pdf
+
 @frappe.whitelist(allow_guest=True)
 def generate_invoice():
 	cart = [{
@@ -66,6 +69,26 @@ def generate_invoice():
 ```
 
 ## validate_url
+
+Function Signature: `validate_url(txt, throw=False, valid_schemes=None)`
+
+`txt`: A string to check validity
+
+`throw`: Weather to throw an exception if `txt` does not represent a valid URL, `False` by default
+
+`valid_schemes`: A string or an iterable (list, tuple or set). If provided, checks the given URL's scheme against this.
+
+This utility function can be used to check if a string represents a valid URL address.
+
+Example Usage:
+
+```py
+from frappe.utils import validate_url
+
+validate_url('google') # False
+validate_url('https://google.com') # True
+validate_url('https://google.com', throw=True) # throws ValidationError
+```
 
 ## validate_email_address and validate_phone
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -18,8 +18,6 @@ These utility methods can be imported from the `frappe.utils` module (and its ne
 
 Returns the current datetime in the format 'yyyy-mm-dd hh:mm:ss'
 
-
-
 ```py
 from frappe.utils import now
 
@@ -31,8 +29,6 @@ now() # '2021-05-25 06:38:52.242515'
 `getdate(string_date=None)`
 
 Converts `string_date` (yyyy-mm-dd) to `datetime.date` object. If no input is provided, current date is returned. Throws an exception if `string_date` is an invalid date string.
-
-
 
 ```py
 from frappe.utils import getdate
@@ -46,8 +42,6 @@ getdate('2000-03-18') # datetime.date(2000, 3, 18)
 `nowdate()`
 
 Returns current date in the format 'yyyy-mm-dd'. `today()` is an alias to `nowdate()`.
-
-
 
 ```py
 from frappe.utils import today, nowdate
@@ -67,8 +61,6 @@ nowdate() # '2021-05-25'
 ```
 
 This function can be quite handy for doing date/datetime deltas, for instance, adding or substracting certain number of days from a particular date/datetime.
-
-
 
 ```py
 from datetime import datetime # from python std library
@@ -91,8 +83,6 @@ add_to_date(None, years=6) # datetime.datetime(2027, 5, 21, 15, 32, 31, 652089)
 
 Takes an ISO time and returns a string representing how long ago the date represents. Very common in communication applications like instant messengers.
 
-
-
 ```py
 from frappe.utils import pretty_date, now, add_to_date
 
@@ -112,8 +102,6 @@ pretty_date(now()) # 'just now'
 
 Converts the given duration value in seconds (float) to duration format.
 
-
-
 ```py
 from frappe.utils import format_duration
 
@@ -130,8 +118,6 @@ format_duration(1000000, hide_days=True) # '277h 46m 40s'
 `comma_and(some_list, add_quotes=True)`
 
 Given a list or tuple `some_list`, returns a string of the format `1st item, 2nd item, .... and last item`. This function uses `frappe._`, so you don't have to worry about the translations for the word `and`. If `add_quotes` is `False`, returns the items without quotes, with quotes otherwise. If the type of `some_list` passed as an argument is something other than a list or tuple, it (`some_list`) is returned as it is.
-
-
 
 ```py
 from frappe.utils import comma_and
@@ -154,8 +140,6 @@ comma_and('abcd') # 'abcd'
 
 This function returns string in words with currency and fraction currency.
 
-
-
 ```py
 from frappe.utils import money_in_words
 
@@ -170,8 +154,6 @@ money_in_words(900.50, 'USD', 'Cents') # 'USD Nine Hundred and Fifty Cents only.
 `validate_json_string(string)`
 
 Raises `frappe.ValidationError` if the given `string` is a valid JSON (JavaScript Object Notation) string. You can use a `try-except` block to handle a call to this function as shown the code snippet below.
-
-
 
 ```py
 import frappe
@@ -195,8 +177,6 @@ except frappe.ValidationError:
 
 This function generates a random string containing `length` number of characters. This can be useful for cryptographic or secret generation for some cases.
 
-
-
 ```py
 from frappe.utils import random_string
 
@@ -212,8 +192,6 @@ random_string(6) #'HNRirG'
 `seq`: An iterable / Sequence
 
 This function returns a list of elements of the given sequence after removing the duplicates. Also, preserves the order, unlike: `list(set(seq))`.
-
-
 
 ```py
 from frappe.utils import unique
@@ -268,8 +246,6 @@ def generate_invoice():
 
 Returns an abbrivated (initials only) version of the given `string` with a maximum of `max_len` letters. It is extensively used in Frappe Framework and ERPNext to generate thumbnail or placeholder images.
 
-
-
 ```py
 from frappe.utils import get_abbr
 
@@ -289,8 +265,6 @@ get_abbr('Mohammad Hussain Nagaria', max_len=3) # 'MHN'
 ```
 This utility function can be used to check if a string represents a valid URL address.
 
-
-
 ```py
 from frappe.utils import validate_url
 
@@ -304,8 +278,6 @@ validate_url('https://google.com', throw=True) # throws ValidationError
 `validate_email_address(email_str, throw=False)`
 
 Returns a string containing the email address or comma-separated list of valid email addresses present in the given `email_str`. If `throw` is `True`, `frappe.InvalidEmailAddressError` is thrown in case of no valid email address in present in the given string else an empty string is returned.
-
-
 
 ```py
 from frappe.utils import validate_email_address
@@ -329,8 +301,6 @@ validate_email_address('some other text') # ''
 
 Returns `True` if `phone_number` (string) is a valid phone number. If `phone_number` is invalid and `throw` is `True`, `frappe.InvalidPhoneNumberError` is thrown.
 
-
-
 ```py
 from frappe.utils import validate_phone_number
 
@@ -348,8 +318,6 @@ validate_phone_number('87345%%', throw=True) # InvalidPhoneNumberError
 `cache()`
 
 Returns the redis connection, which is an instance of class `RedisWrapper` which is inherited from the `redis.Redis` class. You can use this connection to use the Redis cache to store/retrieve key-value pairs.
-
-
 
 ```py
 import frappe
@@ -377,8 +345,6 @@ cache.get('name') # b'frappe'
 For most cases, the above arguments are sufficient but there are many other keyword arguments that can be passed to this function. To see all the keyword arguments, please have a look the implementation of this function (`frappe/__init__.py`).
 
 This function can be used to send email using user's default **Email Account** or global default **Email Account**.
-
-
 
 ```py
 import frappe

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -1,6 +1,6 @@
 ---
 add_breadcrumbs: 1
-title: Utils
+title: Common Utility Functions
 image: /assets/frappe_io/images/frappe-framework-logo-with-padding.png
 metatags:
   description: >
@@ -57,13 +57,15 @@ today() # '2021-05-25'
 nowdate() # '2021-05-25'
 ```
 
-## add_to_date
+## add\_to\_date
 
 Function Signature: `add_to_date(date, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0, as_string=False, as_datetime=False)`
 
+```md
 `date`: A string representation or `datetime` object, uses the current `datetime` if `None` is passed
 `as_string`: Return as string
 `as_datetime`: If `as_string` is True and `as_datetime` is also True, returns a `datetime` string otherwise just the `date` string.
+```
 
 This function can be quite handy for doing date/datetime deltas, for instance, adding or substracting certain number of days from a particular date/datetime.
 
@@ -82,7 +84,6 @@ print(after_10_days) # '2021-05-31'
 add_to_date(datetime.now(), months=2) # datetime.datetime(2021, 7, 21, 15, 31, 18, 119999)
 add_to_date(datetime.now(), days=10, as_string=True, as_datetime=True) # '2021-05-31 15:30:23.757661'
 add_to_date(None, years=6) # datetime.datetime(2027, 5, 21, 15, 32, 31, 652089)
-
 ```
 
 ## pretty_date
@@ -143,13 +144,14 @@ comma_and('abcd') # 'abcd'
 
 > There is also a `comma_or` function which is similar to `comma_and` except the separator, which is `or` in the case of `comma_or`.
 
-## money_in_words
+## money\_in\_words
 
 Function Signature: `money_in_words(number, main_currency=None, fraction_currency=None)`
 
+```md
 `number`: A floating point money amount
-
 `main_currency`: Uses this as the main currency. If not given, tries to fetch from default settings or uses `INR` if not found there.
+```
 
 This function returns string in words with currency and fraction currency.
 
@@ -162,10 +164,9 @@ money_in_words(900) # 'INR Nine Hundred and Fifty Paisa only.'
 money_in_words(900.50) # 'INR Nine Hundred and Fifty Paisa only.'
 money_in_words(900.50, 'USD') # 'USD Nine Hundred and Fifty Centavo only.'
 money_in_words(900.50, 'USD', 'Cents') # 'USD Nine Hundred and Fifty Cents only.'
-
 ```
 
-## validate_json_string
+## validate\_json\_string
 
 Function Signature: `validate_json_string(string)`
 
@@ -203,7 +204,6 @@ from frappe.utils import random_string
 random_string(40) # 'mcrLCrlvkUdkaOe8m5xMI8IwDB8lszwJsWtZFveQ'
 random_string(6) # 'htrB4L'
 random_string(6) #'HNRirG'
-
 ```
 
 ## unique
@@ -222,18 +222,17 @@ from frappe.utils import unique
 unique([1, 2, 3, 1, 1, 1]) # [1, 2, 3]
 unique('abcda') # ['a', 'b', 'c', 'd']
 unique(('Apple', 'Apple', 'Banana', 'Apple')) # ['Apple', 'Banana']
-
 ```
 
 ## get_pdf
 
 Function Signature: `get_pdf(html, options=None, output=None)`
 
+```md
 `html`: HTML string to render
-
 `options`: An optional `dict` for configuration
-
 `output`: A optional `PdfFileWriter` object.
+```
 
 This function uses `pdfkit` and `pyPDF2` modules to generate PDF files from HTML. If `output` is provided, appends the generated pages to this object and returns it, otherwise returns a `byte` stream of the PDF.
 
@@ -284,12 +283,11 @@ get_abbr('Mohammad Hussain Nagaria', max_len=3) # 'MHN'
 
 Function Signature: `validate_url(txt, throw=False, valid_schemes=None)`
 
+```md
 `txt`: A string to check validity
-
 `throw`: Weather to throw an exception if `txt` does not represent a valid URL, `False` by default
-
 `valid_schemes`: A string or an iterable (list, tuple or set). If provided, checks the given URL's scheme against this.
-
+```
 This utility function can be used to check if a string represents a valid URL address.
 
 Example Usage:
@@ -302,7 +300,7 @@ validate_url('https://google.com') # True
 validate_url('https://google.com', throw=True) # throws ValidationError
 ```
 
-## validate_email_address
+## validate\_email\_address
 
 Function Signature: `validate_email_address(email_str, throw=False)`
 
@@ -326,7 +324,7 @@ validate_email_address(
 validate_email_address('some other text') # ''
 ```
 
-## validate_phone_number
+## validate\_phone\_number
 
 Function Signature: `validate_phone_number(phone_number, throw=False)`
 
@@ -367,6 +365,7 @@ cache.get('name') # b'frappe'
 
 Function Signature: `def sendmail(recipients=[], sender="", subject="No Subject", message="No Message", as_markdown=False, template=None, args=None, **kwargs)`
 
+```md
 `recipients`: List of recipients
 `sender`: Email sender. Default is current user or default outgoing account
 `subject`: Email Subject
@@ -374,6 +373,7 @@ Function Signature: `def sendmail(recipients=[], sender="", subject="No Subject"
 `as_markdown`: Convert content markdown to HTML
 `template`: Name of html template (jinja) from templates/emails folder
 `args`: Arguments for rendering the template
+```
 
 For most cases, the above arguments are sufficient but there are many other keyword arguments that can be passed to this function. To see all the keyword arguments, please have a look at this functions implementation (`frappe/__init__.py`).
 

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -3,13 +3,13 @@ add_breadcrumbs: 1
 title: Utils
 image: /assets/frappe_io/images/frappe-framework-logo-with-padding.png
 metatags:
- description: >
-  Utility functions available in Frappe Framework
+  description: >
+    Utility functions available in Frappe Framework
 ---
 
 # Utility Functions
 
-There are many different **utility functions** available in Frappe Framework that you can use to carry out many common operations like date formating, PDF generation and much more. 
+There are many different **utility functions** available in Frappe Framework that you can use to carry out many common operations like date formating, PDF generation and much more.
 
 This utility methods (`utils`) can be imported from the `frappe` module (or nested modules like `frappe.utils` and `frappe.utils.data`) in any Python file of your Frappe app. This list is not at all exhaustive, you can take a peek at the Framework codebase to see what's available.
 
@@ -71,6 +71,7 @@ Function Signature: `format_duration(seconds, hide_days=False)`
 Converts the given duration value in seconds (float) to duration format.
 
 Example Usage:
+
 ```py
 from frappe.utils import format_duration
 
@@ -185,6 +186,20 @@ def generate_invoice():
 
 ## get_abbr
 
+Function Signature: `get_abbr(string, max_len=2)`
+
+Returns an abbrivated (initials only) version of the given `string` with a maximum of `max_len` letters. It is extensively used in Frappe Framework and ERPNext to generate thumbnail or placeholder images.
+
+Example Usage:
+
+```py
+from frappe.utils import get_abbr
+
+get_abbr('Gavin') # 'G'
+get_abbr('Coca Cola Company') # 'CC'
+get_abbr('Mohammad Hussain Nagaria', max_len=3) # 'MHN'
+```
+
 ## validate_url
 
 Function Signature: `validate_url(txt, throw=False, valid_schemes=None)`
@@ -212,4 +227,3 @@ validate_url('https://google.com', throw=True) # throws ValidationError
 ## frappe.cache()
 
 ## frappe.sendmail()
-

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -29,6 +29,19 @@ now() # '2021-05-25 06:38:52.242515'
 
 ## getdate
 
+Function Signature: `getdate(string_date=None)`
+
+Converts `string_date` (yyyy-mm-dd) to `datetime.date` object. If no input is provided, current date is returned. Throws an exception if `string_date` is an invalid date string.
+
+Example Usage:
+
+```py
+from frappe.utils import getdate
+
+getdate() # datetime.date(2021, 5, 25)
+getdate('2000-03-18') # datetime.date(2000, 3, 18)
+```
+
 ## today
 
 ## add_to_date

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -109,6 +109,28 @@ money_in_words(900.50, "USD", "Cents") # 'USD Nine Hundred and Fifty Cents only.
 
 ## validate_json_string
 
+Function Signature: `validate_json_string(string)`
+
+Raises `frappe.ValidationError` if the given `string` is a valid JSON (JavaScript Object Notation) string. You can use a `try-except` block to handle a call to this function as shown the code snippet below.
+
+Example Usage:
+
+```py
+import frappe
+from frappe.utils import validate_json_string
+
+# No Exception thrown
+validate_json_string('[]')
+validate_json_string('[{}]')
+validate_json_string('[{"player": "one", "score": 199}]')
+
+try:
+	# Throws frappe.ValidationError
+	validate_json_string('invalid json')
+except frappe.ValidationError:
+	print('Not a valid JSON string')
+```
+
 ## random_string
 
 Function Signature: `random_string(length)`

--- a/frappe_docs/www/docs/user/en/api/utils.md
+++ b/frappe_docs/www/docs/user/en/api/utils.md
@@ -101,6 +101,23 @@ random_string(6) #'HNRirG'
 
 ## unique
 
+Function Signature: `unique(seq)`
+
+`seq`: An iterable / Sequence
+
+This function returns a list of elements of the given sequence after removing the duplicates. Also, preserves the order, unlike: `list(set(seq))`.
+
+Example Usage:
+
+```py
+from frappe.utils import unique
+
+unique([1, 2, 3, 1, 1, 1]) # [1, 2, 3]
+unique('abcda') # ['a', 'b', 'c', 'd']
+unique(('Apple', 'Apple', 'Banana', 'Apple')) # ['Apple', 'Banana']
+
+```
+
 ## get_pdf
 
 Function Signature: `get_pdf(html, options=None, output=None)`


### PR DESCRIPTION
Add docs for must-know **Python utility functions** available in Frappe Framework. This function docs include datetime utilities, PDF generation, cache, string formatting, validations and **more**.

![frappe_util_docs](https://user-images.githubusercontent.com/34810212/119461339-355fa180-bd5d-11eb-8d12-fe2d11a93df9.png)

![docs_utils_3](https://user-images.githubusercontent.com/34810212/119461928-d6e6f300-bd5d-11eb-83dd-e05d8e10df79.png)
