### PR TITLE
docs: Fix typo in Tutorial

### DIFF
--- a/frappe_docs/www/docs/user/en/tutorial/types-of-doctype.md
+++ b/frappe_docs/www/docs/user/en/tutorial/types-of-doctype.md
@@ -256,7 +256,7 @@ class LibraryTransaction(Document):
             self.validate_maximum_limit()
             # set the article status to be Issued
             article = frappe.get_doc("Article", self.article)
-            article.status == "Issued"
+            article.status = "Issued"
             article.save()
 
         elif self.type == "Return":


### PR DESCRIPTION
`article.status == "Issued"` to `article.status = "Issued"`