### PR TITLE
fix: corrected the name of argument to frappe.db.sql

### DIFF
--- a/frappe_docs/www/docs/user/en/api/database.md
+++ b/frappe_docs/www/docs/user/en/api/database.md
@@ -207,14 +207,14 @@ Rollbacks current transaction. Calls SQL `ROLLBACK`.
 > early in a transaction.
 
 ## frappe.db.sql
-`frappe.db.sql(query, filters, as_dict)`
+`frappe.db.sql(query, values, as_dict)`
 
 Execute an arbitrary SQL query. This may be useful for complex server side reports with join statements, adjusting the database to new features, etc.
 
 Example:
 
 ```python
-filters = {'company': 'Frappe Technologies Inc'}
+values = {'company': 'Frappe Technologies Inc'}
 data = frappe.db.sql("""
 	SELECT
 		acc.account_number
@@ -224,7 +224,7 @@ data = frappe.db.sql("""
 		LEFT JOIN `tabAccount` acc 
 		ON gl.account = acc.name
 	WHERE gl.company = %(company)s
-""", filters=filters, as_dict=0)
+""", values=values, as_dict=0)
 ```
 
 > Avoid using this method as it will bypass validations and integrity checks. It's always better to use [frappe.get_doc](https://frappeframework.com/docs/user/en/api/document#frappeget_doc), [frappe.db.get_list](#frappedbget_list), etc., if possible.


### PR DESCRIPTION
The name of the second argument to `frappe.db.sql` is `values`. It was incorrectly mentioned as `filters`.