### PR TITLE
docs: note about scheduled job migration

### DIFF
--- a/frappe_docs/www/docs/user/en/python-api/hooks.md
+++ b/frappe_docs/www/docs/user/en/python-api/hooks.md
@@ -961,6 +961,8 @@ def update_database_usage():
 	pass
 ```
 
+> After changing any scheduled events in `hooks.py`, you need to run `bench migrate` for changes to take effect.
+
 ### Available Events
 
 - `hourly`, `daily`, `weekly`, `monthly`


### PR DESCRIPTION
Add a note about the migration of scheduled jobs in `hooks.py`

Avoids confusion like : https://discuss.erpnext.com/t/hooks-py-updated-but-scheduled-job-not-running/75437