### PR TITLE
docs: Form dirty API

### DIFF
--- a/frappe_docs/www/docs/user/en/api/form.md
+++ b/frappe_docs/www/docs/user/en/api/form.md
@@ -250,6 +250,14 @@ if (frm.is_dirty()) {
 }
 ```
 
+### frm.dirty()
+
+Set form values as changed.
+
+```js
+frm.dirty();
+```
+
 ### frm.is_new
 
 Check if the form is new and is not saved yet.

--- a/frappe_docs/www/docs/user/en/api/form.md
+++ b/frappe_docs/www/docs/user/en/api/form.md
@@ -250,13 +250,19 @@ if (frm.is_dirty()) {
 }
 ```
 
-### frm.dirty()
+### frm.dirty
 
-Set form values as changed.
+Set form as "dirty". This is used to set form as dirty when document values are
+changed. This triggers the **_"Not Saved"_** indicator in the Form Views.
 
 ```js
+frm.doc.browser_data = navigator.appVersion;
 frm.dirty();
+frm.save();
 ```
+
+Calling save without setting the form dirty will trigger a **_"No changes in
+document"_** toast.
 
 ### frm.is_new
 


### PR DESCRIPTION
Sometimes some manipulations doesn't set form as dirty so frm.dirty() method should be documented.