### PR TITLE
docs: fix docs of child table events

### DIFF
--- a/frappe_docs/www/docs/user/en/api/form.md
+++ b/frappe_docs/www/docs/user/en/api/form.md
@@ -120,10 +120,10 @@ These events are triggered in the context of a Child Table. Hence, along with
 `frm`, they will also get the `cdt` (Child DocType) and `cdn` (Child Docname)
 parameters in their handler functions.
 
-Imagine our "ToDo" DocType has a field called "links" that contains a Child Table. This Child Table is defined in a DocType called "Dynamic Link". We want our code to run whenever a new row get's added to the table.
+Imagine our "ToDo" DocType has a field called "links" that contains a Child Table. This Child Table is defined in a DocType called "Dynamic Link". We want our code to run whenever a row is added to the table.
 
 ```js
-// this code is located inside `todo.js``
+// this code is located inside `todo.js`
 
 frappe.ui.form.on('Dynamic Link', { // The child table is defined in a DoctType called "Dynamic Link"
 	links_add(frm, cdt, cdn) { // "links" is the name of the table field in ToDo, "_add" is the event

--- a/frappe_docs/www/docs/user/en/api/form.md
+++ b/frappe_docs/www/docs/user/en/api/form.md
@@ -120,17 +120,21 @@ These events are triggered in the context of a Child Table. Hence, along with
 `frm`, they will also get the `cdt` (Child DocType) and `cdn` (Child Docname)
 parameters in their handler functions.
 
+Imagine our "ToDo" DocType has a field called "links" that contains a Child Table. This Child Table is defined in a DocType called "Dynamic Link". We want our code to run whenever a new row get's added to the table.
+
 ```js
-frappe.ui.form.on('ToDo', {
-	// cdt, cdn are also passed as parameters
-	// links is the name of Table field in ToDo
-	links_add(frm, cdt, cdn) {
-		// cdt is Child DocType
-		// cdn is Child docname
-		// They are useful for identifying the row which triggered this event
-		// In this case, the row that was added
+// this code is located inside `todo.js``
+
+frappe.ui.form.on('Dynamic Link', { // The child table is defined in a DoctType called "Dynamic Link"
+	links_add(frm, cdt, cdn) { // "links" is the name of the table field in ToDo, "_add" is the event
+		// frm: current ToDo form
+		// cdt: child DocType 'Dynamic Link'
+		// cdn: child docname (something like 'a6dfk76')
+		// cdt and cdn are useful for identifying which row triggered this event
+
+		frappe.msgprint('A row has been added to the links table 🎉 ');
 	}
-})
+});
 ```
 
 Event Name            | Description


### PR DESCRIPTION
 Docs on child table events were wrong ([since 2016, it seems](https://discuss.erpnext.com/t/solved-cant-trigger-child-table--add-or--remove-events/15024/4?u=rmeyer) 😕 ).

The event functions need to be attached to the child doctype, not the parent doctype.