### PR TITLE
docs: Redis namespaces

### DIFF
--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -29,7 +29,7 @@ This guide assumes you are using a personal computer, VPS or a bare-metal server
 ```
   Python 3.6+
   Node.js 12
-  Redis 5                                       (caching and realtime updates)
+  Redis 6                                       (caching and realtime updates)
   MariaDB 10.3.x / Postgres 9.5.x               (to run database driven apps)
   yarn 1.12+                                    (js dependency manager)
   pip 20+                                       (py dependency manager)

--- a/frappe_docs/www/docs/user/en/production-setup.md
+++ b/frappe_docs/www/docs/user/en/production-setup.md
@@ -87,3 +87,23 @@ bench update --bench
 # update python packages and node_modules
 bench update --requirements
 ```
+
+## Redis Namespaces
+
+Namespaces help to secure user's data. Multiple benches can use the same Redis instance without worrying about namespace conflicts. You can enable Redis namespaces in Frappe by following the given setup (for now Frappe supports namespaces for Redis Queue at bench level).
+
+You can create Redis users and configure Frappe with credentials using bench create-rq-users CLI.
+
+```bash
+bench create-rq-users
+
+# Optional flags
+# --use-rq-auth Enable Redis authentication for all bench sites
+# --set-admin-password sets default user admin password
+```
+
+Above command generates an ACL file in the bench configs directory. Make sure that Redis_queue.conf file is configured to use an acl file if not already (Alternatively, run `bench setup redis` with the latest version of the Bench CLI).
+
+```bash
+aclfile [frappe-bench-absolute-path]/config/redis_queue.acl
+```


### PR DESCRIPTION
Docs relate to the Redis namespaces introduced in PR https://github.com/frappe/frappe/pull/13746 . 