### PR TITLE
fix: Docs for frontmatter blocks and context keys

### DIFF
--- a/frappe_docs/www/docs/user/en/portal-pages.md
+++ b/frappe_docs/www/docs/user/en/portal-pages.md
@@ -5,6 +5,7 @@ metatags:
  description: >
   Frappe Framework allows you to host server rendered web pages which are great
   for SEO. You can also create public portals for external users.
+safe_render: false
 ---
 
 # Portal Pages
@@ -163,6 +164,100 @@ Usage in template
 > Since Portal Pages are built using Jinja, frappe provides a standard
 > [API](/docs/user/en/api/jinja) to use in jinja templates.
 
+#### List of standard context keys
+
+Here is a list of all the standard keys that can be set in `context` and their
+functionalities.
+
+| Context Key           | Functionality                            |
+| --------------------- | ---------------------------------------- |
+| `add_breadcrumbs`     | Add breadcrumbs to page                  |
+| `no_breadcrumbs`      | Remove breadcrumbs from page             |
+| `show_sidebar`        | Show web sidebar                         |
+| `safe_render`         | Toggle [safe_render](#safe_render)       |
+| `no_header`           | Hide header                              |
+| `no_cache`            | Disable caching for this page            |
+| `sitemap`             | Include/exclude page in sitemap          |
+| `add_next_prev_links` | Add Next and Previous navigation buttons |
+| `title`               | Set the page title                       |
+
+##### safe_render
+
+`frappe.render_template` does not render a template which contains the string
+`.__` to prevent running any illegal python expressions. You may want to disable
+this behaviour if you are sure that the content is safe. To do this, you need to
+turn off safe render by setting the value of `safe_render` key to `False` in
+context.
+
+#### Set context via frontmatter
+
+You can also set values in context using a frontmatter block. Frontmatter blocks
+can be used to set static values specific to a page like meta tags.
+
+Take a look at the following example:
+```bash
+---
+title: Introduction
+metatags:
+  description: This is description for the introduction page
+---
+
+# Introduction
+This is an introduction page
+```
+
+The above frontmatter block will update the `context` dict with the following values:
+```py
+{
+	'title': 'Introduction',
+	'metatags': {
+		'description': 'This is description for the introduction page'
+	}
+}
+```
+
+#### Set context via comments
+
+You can also set some values in context by adding html comments in your pages.
+
+For example by adding `<!-- add-breadcrumbs -->` to your `.html` or `.md` file,
+`context.add_breadcrumbs` will be set to `True` and it will automatically generate
+breadcrumbs based on folder structure.
+
+{% raw %}
+```html
+<!-- add-breadcrumbs -->
+
+<h1>{{ _("About Us") }}</h1>
+<div class="row">
+    <div class="col-sm-6">
+		We believe that great companies are driven by excellence,
+		and add value to both its customers and society.
+		You will find our team embibes these values.
+	</div>
+
+	{% if about_us_settings.show_contact_us %}
+	<a href="/contact" class="btn btn-primary">Contact Us</a>
+	{% endif %}
+</div>
+```
+{% endraw %}
+
+Here is a list of keys that you can set and their context values:
+
+| Comment                                                       | Context Value                                           |
+| ------------------------------------------------------------- | ------------------------------------------------------- |
+| `<!-- add-breadcrumbs -->`                                    | `add_breadcrumbs = 1`                                   |
+| `<!-- no-breadcrumbs -->`                                     | `no_breadcrumbs = 1`                                    |
+| `<!-- show-sidebar -->`                                       | `show_sidebar = 1`                                      |
+| `<!-- no-header -->`                                          | `no_header = 1`                                         |
+| `<!-- no-cache -->`                                           | `no_cache = 1`                                          |
+| `<!-- no-sitemap -->`                                         | `sitemap = 0`                                           |
+| `<!-- sitemap -->`                                            | `sitemap = 1`                                           |
+| `<!-- add-next-prev-links -->`                                | `add_next_prev_links = 1`                               |
+| `<!-- title: Custom Title -->`                                | `title = 'Custom Title'`                                |
+| `<!-- base_template: custom_app/path/to/custom_base.html -->` | `base_template = 'custom_app/path/to/custom_base.html'` |
+
 ### Custom CSS and JS
 
 You can add custom CSS and JS for your pages by dropping a `.css` or `.js` file
@@ -184,43 +279,3 @@ The home page for your portal can be defined in
 1. Portal Settings (this will be for logged in users)
 1. Via Hook `get_website_user_home_page`
 1. Website Settings (this will be for non logged in users as well - i.e. Guest)
-
-### Magic Comments
-
-You can configure some functionalities by adding magic comments in your pages.
-
-For example by adding `<!-- add-breadcrumbs -->` to your `.html` or `.md` file,
-frappe will automatically generate breadcrumbs based on folder structure.
-
-{% raw %}
-```html
-<!-- add-breadcrumbs -->
-
-<h1>{{ _("About Us") }}</h1>
-<div class="row">
-    <div class="col-sm-6">
-		We believe that great companies are driven by excellence,
-		and add value to both its customers and society.
-		You will find our team embibes these values.
-	</div>
-
-	{% if about_us_settings.show_contact_us %}
-	<a href="/contact" class="btn btn-primary">Contact Us</a>
-	{% endif %}
-</div>
-```
-{% endraw %}
-
-Here is a list of all magic comments and their functionalities.
-
-Comment							| Functionality
---------------------------------|----------------
-`<!-- add-breadcrumbs -->`		| Add breadcrumbs to page
-`<!-- no-breadcrumbs -->`		| Remove breadcrumbs from page
-`<!-- show-sidebar -->`			| Show web sidebar
-`<!-- no-cache -->`				| Disable caching for this page
-`<!-- no-sitemap -->`			| Don't include page in sitemap
-`<!-- sitemap -->`				| Include page in sitemap
-`<!-- add-next-prev-links -->`	| Add Next and Previous navigation buttons
-`<!-- title: Custom Title -->`	| Set the page title
-`<!-- base_template: custom_app/path/to/custom_base.html -->` | Override base_template for this page


### PR DESCRIPTION
- added description for safe_render


![image](https://user-images.githubusercontent.com/9355208/128598960-9e3fe91a-8d9c-4daa-b44e-77ef36f93a9b.png)
