### PR TITLE
fix: change installation command to mariadb 10.3

### DIFF
--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -50,7 +50,7 @@ Install [Homebrew](https://brew.sh/). It makes it easy to install packages on ma
 Now, you can easily install the required packages by running the following command
 
 ```bash
-brew install python git redis mariadb@10.5
+brew install python git redis mariadb@10.3
 brew install --cask wkhtmltopdf
 ```
 

--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -50,7 +50,7 @@ Install [Homebrew](https://brew.sh/). It makes it easy to install packages on ma
 Now, you can easily install the required packages by running the following command
 
 ```bash
-brew install python git redis mariadb
+brew install python git redis mariadb@10.5
 brew install --cask wkhtmltopdf
 ```
 


### PR DESCRIPTION
Mac - Installation on 10.6 fails, while the [support for it is underway](https://github.com/frappe/frappe/pull/13954); old versions will likely not get it. Hence safe bet is to recommend installing 10.5.
Linux - 10.3 is suggested, so not a problem