### PR TITLE
fix: macOS MariaDB config paths

### DIFF
--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -135,7 +135,7 @@ brew install --cask wkhtmltopdf
 Now, edit the MariaDB configuration file.
 
 ```bash 
-nano /opt/homebrew/etc/my.cnf
+nano /usr/local/etc/my.cnf
 ```
 
 And add this configuration

--- a/frappe_docs/www/docs/user/en/installation.md
+++ b/frappe_docs/www/docs/user/en/installation.md
@@ -57,7 +57,7 @@ brew install --cask wkhtmltopdf
 Now, edit the MariaDB configuration file.
 
 ```bash
-nano /etc/mysql/my.cnf
+nano /usr/local/etc/my.cnf
 ```
 
 And add this configuration
@@ -135,7 +135,7 @@ brew install --cask wkhtmltopdf
 Now, edit the MariaDB configuration file.
 
 ```bash 
-nano /usr/local/etc/my.cnf
+nano /opt/homebrew/etc/my.cnf
 ```
 
 And add this configuration


### PR DESCRIPTION
Installation documentation now has incorrect MariaDB config paths. This PR fixes this.