### PR TITLE
docs: Update Bench Commands

### DIFF
--- a/frappe_docs/commands.py
+++ b/frappe_docs/commands.py
@@ -1,0 +1,44 @@
+import click
+
+
+@click.command("add-command-reference")
+@click.argument("command", required=True)
+@click.option("--force", "-f", is_flag=True)
+def bench_reference(command, force):
+	import os
+	from frappe.commands import commands
+	from frappe_docs.www.docs.user.en.bench.reference import TEMPLATE
+
+	FILE_PATH = f"../apps/frappe_docs/frappe_docs/www/docs/user/en/bench/reference/{command}.md"
+
+	cmd = [x for x in commands if x.name == command]
+	if not cmd:
+		import sys
+
+		print("Command not found")
+		sys.exit(1)
+
+	import jinja2
+
+	cmd = cmd[0]
+
+	flags = [x for x in cmd.params if x.is_flag]
+	options = [x for x in cmd.params if not x.is_flag]
+	required_stuff = "".join(x.name for x in options + flags if x.required)
+	kwargs = {
+		**cmd.__dict__,
+		"options": options,
+		"flags": flags,
+		"command_usage": f"bench {cmd.name} [OPTIONS] {required_stuff}",
+	}
+	file_content = jinja2.Template(TEMPLATE).render(kwargs)
+
+	if os.path.exists(FILE_PATH) and not force:
+		print(file_content)
+	else:
+		with open(FILE_PATH, "w") as f:
+			f.write(file_content)
+		print(f"File created at {os.path.realpath(FILE_PATH)}")
+
+
+commands = [bench_reference]

--- a/frappe_docs/www/docs/user/en/bench/_sidebar.json
+++ b/frappe_docs/www/docs/user/en/bench/_sidebar.json
@@ -17,59 +17,10 @@
 			{
 				"title": "Extending the CLI",
 				"route": "/docs/user/en/bench/extending-the-cli"
-			}
-		]
-	},
-	{
-		"group_title": "References",
-		"group_items": [
-			{
-				"title": "new-site",
-				"route": "/docs/user/en/bench/reference/new-site"
 			},
 			{
-				"title": "drop-site",
-				"route": "/docs/user/en/bench/reference/drop-site"
-			},
-			{
-				"title": "migrate",
-				"route": "/docs/user/en/bench/reference/migrate"
-			},
-			{
-				"title": "backup",
-				"route": "/docs/user/en/bench/reference/backup"
-			},
-			{
-				"title": "reinstall",
-				"route": "/docs/user/en/bench/reference/reinstall"
-			},
-			{
-				"title": "list-apps",
-				"route": "/docs/user/en/bench/reference/list-apps"
-			},
-			{
-				"title": "uninstall-app",
-				"route": "/docs/user/en/bench/reference/uninstall-app"
-			},
-			{
-				"title": "show-config",
-				"route": "/docs/user/en/bench/reference/show-config"
-			},
-			{
-				"title": "set-config",
-				"route": "/docs/user/en/bench/reference/set-config"
-			},
-			{
-				"title": "restore",
-				"route": "/docs/user/en/bench/reference/restore"
-			},
-			{
-				"title": "partial-restore",
-				"route": "/docs/user/en/bench/reference/partial-restore"
-			},
-			{
-				"title": "version",
-				"route": "/docs/user/en/bench/reference/bench-version"
+				"title": "References",
+				"route": "/docs/user/en/bench/reference"
 			}
 		]
 	},

--- a/frappe_docs/www/docs/user/en/bench/extending-the-cli.md
+++ b/frappe_docs/www/docs/user/en/bench/extending-the-cli.md
@@ -19,7 +19,7 @@ commands.
 
 The directory structure with a Frappe App `flags` may be visualized as:
 
-```
+```bash
 frappe-bench
 |──apps
     |── frappe

--- a/frappe_docs/www/docs/user/en/bench/frappe-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/frappe-commands.md
@@ -230,6 +230,26 @@ just in case.
    `currentsite.txt`.
 
 
+### Database Maintenance Commands
+
+Set of commands that are related to database management and maintenance. These
+commands offer more control to your site's database. You may want to fine-tune
+your deployment to fit your site's needs over time.
+
+#### Table Transformations
+
+The `transform-database` command allows you to manage the settings of your
+site's tables. At this point, you can switch `engine` and `row_format` settings for
+select tables on your site database.
+
+```bash
+bench --site {site} transform-database --tables {tables}
+```
+
+For more information and examples, see the [bench
+transform-database](/docs/user/en/bench/reference/transform-database) reference.
+
+
 ### Scheduler Commands
 
 Commands to manage and review the scheduler and background jobs' statuses for
@@ -327,6 +347,7 @@ version](/docs/user/en/bench/reference/bench-version) reference.
    directory, all files ending with `.json` are imported
  - **jupyter**: Starting a Jupyter Notebook server.
  - **make-app**: Creates a boilerplate Frappe Application.
+ - **db-console**: Start the interactive DB console for your site. This command is an alias over commands: mariadb, postgres
  - **mariadb**: Start the MySQL interactive console for the mysql site.
  - **postgres**: Start the PostgreSQL interactive console for the postgres site.
  - **rebuild-global-search**: Setup help table in the current site (called after

--- a/frappe_docs/www/docs/user/en/bench/frappe-commands.md
+++ b/frappe_docs/www/docs/user/en/bench/frappe-commands.md
@@ -249,6 +249,41 @@ bench --site {site} transform-database --tables {tables}
 For more information and examples, see the [bench
 transform-database](/docs/user/en/bench/reference/transform-database) reference.
 
+#### Table Trimming
+
+Docfields removed from a particular DocType may not be deleted from their Database
+tables. This is by design to prevent premature data loss in Frappe. This won't be
+problematic for the most part, however, at some point you may face issues due to this
+lingering data.
+
+Some benefits of regular table trimming are:
+
+- Smaller backup sizes
+- Reduced time taken to backup sites
+- Reduced Site Database Usages
+- Optimized queries in case of `SELECT *`
+- Database is clean and doesn't have anything hidden or redundant data
+
+```bash
+bench trim-tables [OPTIONS]
+```
+
+For more information and examples, see the [bench
+trim-tables](/docs/user/en/bench/reference/trim-tables) reference.
+
+#### Database Trimming
+
+Deleting DocTypes from the list view may not delete their corresponding tables from
+the database. Migrations may leave ghost tables in your Site Database at times. This
+ may be done for the sake of redundancy, for recovery in case your data is corrupted
+ or lost, or simply, in cases of human error.
+
+```bash
+bench trim-database [OPTIONS]
+```
+
+For more information and examples, see the [bench
+trim-database](/docs/user/en/bench/reference/trim-database) reference.
 
 ### Scheduler Commands
 

--- a/frappe_docs/www/docs/user/en/bench/index.md
+++ b/frappe_docs/www/docs/user/en/bench/index.md
@@ -35,5 +35,6 @@ wrappers around and invoke multiple Frappe commands such as `backup` and
 
 1. [Bench Commands](/docs/user/en/bench/bench-commands)
 1. [Frappe Commands](/docs/user/en/bench/frappe-commands)
+1. [Command References](/docs/user/en/bench/reference)
 1. [Extending the CLI](/docs/user/en/bench/extending-the-cli)
 

--- a/frappe_docs/www/docs/user/en/bench/reference/__init__.py
+++ b/frappe_docs/www/docs/user/en/bench/reference/__init__.py
@@ -1,0 +1,50 @@
+
+TEMPLATE = """---
+title: Bench - bench {{ name }}
+metatags:
+ description: >
+  {{ help }}
+---
+
+# bench {{ name }}
+
+## Usage
+
+```bash
+{{ command_usage }}
+```
+
+## Description
+
+{{ description_long }}
+
+{% if options %}
+## Options
+
+{% for option in options %}
+ - `{{ option.name }}` {{ option.help }}
+{% endfor %}
+
+{% endif %}
+
+{% if flags %}
+## Flags
+{% for flag in flags %}
+ - `{{ flag.name }}` {{ flag.help }}
+{% endfor %}
+{% endif %}
+
+### Examples
+
+1. Description of example 1.
+
+    ```bash
+    bench {{ name }} content of example 1
+    ```
+
+1. Description of example 2.
+
+    ```bash
+    bench {{ name }} content of example 2
+    ```
+"""

--- a/frappe_docs/www/docs/user/en/bench/reference/_sidebar.json
+++ b/frappe_docs/www/docs/user/en/bench/reference/_sidebar.json
@@ -1,0 +1,92 @@
+[
+	{
+		"group_title": "Bench CLI",
+		"group_items": [
+			{
+				"title": "What is Bench?",
+				"route": "/docs/user/en/bench"
+			},
+			{
+				"title": "Bench Commands",
+				"route": "/docs/user/en/bench/bench-commands"
+			},
+			{
+				"title": "Frappe Commands",
+				"route": "/docs/user/en/bench/frappe-commands"
+			},
+			{
+				"title": "Extending the CLI",
+				"route": "/docs/user/en/bench/extending-the-cli"
+			},
+			{
+				"title": "References",
+				"route": "/docs/user/en/bench/reference"
+			}
+		]
+	},
+	{
+		"group_title": "References",
+		"group_items": [
+			{
+				"title": "new-site",
+				"route": "/docs/user/en/bench/reference/new-site"
+			},
+			{
+				"title": "drop-site",
+				"route": "/docs/user/en/bench/reference/drop-site"
+			},
+			{
+				"title": "migrate",
+				"route": "/docs/user/en/bench/reference/migrate"
+			},
+			{
+				"title": "backup",
+				"route": "/docs/user/en/bench/reference/backup"
+			},
+			{
+				"title": "reinstall",
+				"route": "/docs/user/en/bench/reference/reinstall"
+			},
+			{
+				"title": "list-apps",
+				"route": "/docs/user/en/bench/reference/list-apps"
+			},
+			{
+				"title": "uninstall-app",
+				"route": "/docs/user/en/bench/reference/uninstall-app"
+			},
+			{
+				"title": "show-config",
+				"route": "/docs/user/en/bench/reference/show-config"
+			},
+			{
+				"title": "set-config",
+				"route": "/docs/user/en/bench/reference/set-config"
+			},
+			{
+				"title": "restore",
+				"route": "/docs/user/en/bench/reference/restore"
+			},
+			{
+				"title": "partial-restore",
+				"route": "/docs/user/en/bench/reference/partial-restore"
+			},
+			{
+				"title": "version",
+				"route": "/docs/user/en/bench/reference/bench-version"
+			},
+			{
+				"title": "transform-database",
+				"route": "/docs/user/en/bench/reference/transform-database"
+			},
+			{
+				"title": "trim-database",
+				"route": "/docs/user/en/bench/reference/trim-database"
+			},
+			{
+				"title": "trim-tables",
+				"route": "/docs/user/en/bench/reference/trim-tables"
+			}
+		]
+	}
+]

--- a/frappe_docs/www/docs/user/en/bench/reference/index.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/index.md
@@ -1,0 +1,32 @@
+---
+title: Bench - References
+metatags:
+ description: >
+  Reference sheet for Frappe's CLI commands.
+---
+
+# Commands Reference
+
+Manual for the commands under Frappe & Bench, accessible via the Bench CLI.
+
+
+
+## Site Commands
+
+1. [new-site](/docs/user/en/bench/reference/new-site)
+1. [drop-site](/docs/user/en/bench/reference/drop-site)
+1. [migrate](/docs/user/en/bench/reference/migrate)
+1. [backup](/docs/user/en/bench/reference/backup)
+1. [reinstall](/docs/user/en/bench/reference/reinstall)
+1. [list-apps](/docs/user/en/bench/reference/list-apps)
+1. [uninstall-app](/docs/user/en/bench/reference/uninstall-app)
+1. [show-config](/docs/user/en/bench/reference/show-config)
+1. [set-config](/docs/user/en/bench/reference/set-config)
+1. [restore](/docs/user/en/bench/reference/restore)
+1. [partial-restore](/docs/user/en/bench/reference/partial-restore)
+
+## Frappe Utility Commands
+
+1. [version](/docs/user/en/bench/reference/bench-version)
+
+

--- a/frappe_docs/www/docs/user/en/bench/reference/index.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/index.md
@@ -29,4 +29,8 @@ Manual for the commands under Frappe & Bench, accessible via the Bench CLI.
 
 1. [version](/docs/user/en/bench/reference/bench-version)
 
+## Database Maintenance Commands
 
+1. [transform-database](/docs/user/en/bench/reference/transform-database)
+1. [trim-database](/docs/user/en/bench/reference/trim-database)
+1. [trim-tables](/docs/user/en/bench/reference/trim-tables)

--- a/frappe_docs/www/docs/user/en/bench/reference/transform-database.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/transform-database.md
@@ -1,0 +1,47 @@
+---
+title: Bench - bench transform-database
+metatags:
+ description: >
+  Change tables' internal settings changing engine and row formats
+---
+
+# bench transform-database
+
+> This command is added in **Version 14**, and supports only **MariaDB**
+
+## Usage
+
+```bash
+bench transform-database [OPTIONS] table
+```
+
+## Description
+
+The `transform-database` command allows you to manage the settings of your site's tables. At this point, you can switch engines and row_format settings for select tables on your site database.
+
+> MariaDB 10.6 deprecated the COMPRESSED ROW_FORMAT which was Frappe's default option for a very long time. This command was added to handle upgrades to later versions of MariaDB. For more information on this, refer to the [PR](https://github.com/frappe/frappe/pull/13954).
+
+
+## Options
+
+ - `--table` Comma separated name of tables to convert. To convert all tables, pass 'all' **[required]**
+ - `--engine` Choice of storage engine for said table(s). Options available are *InnoDB* and *MyISAM*.
+ - `--row_format` Set *ROW_FORMAT* parameter for said table(s). Options available are *DYNAMIC*, *COMPACT*, *REDUNDANT*, *COMPRESSED*.
+
+## Flags
+
+ - `failfast` Exit on first failure occurred
+
+### Examples
+
+1. Consider a scenario where you'd want to change the engine of a table *"tabAccess Record"* to `MyISAM`. You may want to do this if it's a log table that's dealing with huge volumes of writes and very little reads.
+
+    ```bash
+    bench --site {site} transform-database --table 'tabAccess Record' --engine 'MyISAM'
+    ```
+
+1. You've upgraded MariaDB on your current server from 10.3 to 10.7. You're going to have to convert all the tables that used the COMPRESSED row_format to the new default, ie `DYNAMIC`. You'd want to run the following command.
+
+    ```bash
+    bench --site {site} transform-database --table 'all' --row_format 'DYNAMIC'
+    ```

--- a/frappe_docs/www/docs/user/en/bench/reference/trim-database.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/trim-database.md
@@ -20,6 +20,11 @@ the database. Migrations may leave ghost tables in your Site Database at times. 
  may be done for the sake of redundancy, for recovery in case your data is corrupted
  or lost, or simply, in cases of human error.
 
+This command drops any tables that seem to be remnants like the above mentioned. It will
+attempt a partial backup of the tables before dropping them. In case, these tables were
+required, and were dropped errenously, you can restore them in your site's database using
+the [`partial-restore`](/docs/user/en/bench/reference/partial-restore) command.
+
 ## Options
 
  - `--format`, `-f` Set output format. Available options are JSON and Table. Defaults to Table.

--- a/frappe_docs/www/docs/user/en/bench/reference/trim-database.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/trim-database.md
@@ -1,0 +1,46 @@
+---
+title: Bench - bench trim-database
+metatags:
+ description: >
+  None
+---
+
+# bench trim-database
+
+## Usage
+
+```bash
+bench trim-database [OPTIONS]
+```
+
+## Description
+
+Deleting DocTypes from the list view may not delete their corresponding tables from
+the database. Migrations may leave ghost tables in your Site Database at times. This
+ may be done for the sake of redundancy, for recovery in case your data is corrupted
+ or lost, or simply, in cases of human error.
+
+## Options
+
+ - `--format`, `-f` Set output format. Available options are JSON and Table. Defaults to Table.
+
+## Flags
+
+ - `--dry-run` Show what would be deleted.
+ - `--no-backup` Do not backup the site prior to the trimming.
+
+### Examples
+
+1. You want to figure out what data will be deleted if you run this command? Run it with the
+    `--dry-run` flag.
+
+    ```bash
+    bench --site {site} trim-database --dry-run
+    ```
+
+1. Want to build over this command and need the data to be machine parsable? Set the output
+    `--format` to **json**.
+
+    ```bash
+    bench --site {site} trim-database --format json
+    ```

--- a/frappe_docs/www/docs/user/en/bench/reference/trim-tables.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/trim-tables.md
@@ -28,6 +28,11 @@ Some benefits of regular table trimming are:
 - Optimized queries in case of `SELECT *`
 - Database is clean and doesn't have anything hidden or redundant data
 
+This command modifies the schema of tables in your site's database. It will by default,
+take a full backup of your entire database before modifying them. In case, these tables
+ were modified errenously, you can restore your site to it's original state using
+the [`restore`](/docs/user/en/bench/reference/restore) command.
+
 ## Options
 
  - `--format`, `-f` Set output format. Available options are JSON and TEXT.

--- a/frappe_docs/www/docs/user/en/bench/reference/trim-tables.md
+++ b/frappe_docs/www/docs/user/en/bench/reference/trim-tables.md
@@ -1,0 +1,51 @@
+---
+title: Bench - bench trim-tables
+metatags:
+  description: >
+    Trim ghost columns in your DocType's tables
+---
+
+# bench trim-tables
+
+## Usage
+
+```bash
+bench trim-tables [OPTIONS]
+```
+
+## Description
+
+Docfields removed from a particular DocType may not be deleted from their
+Database tables. This is by design to prevent premature data loss in Frappe.
+This won't be problematic for the most part, however, at some point you may face
+issues due to this lingering data.
+
+Some benefits of regular table trimming are:
+
+- Smaller backup sizes
+- Reduced time taken to backup sites
+- Reduced Site Database Usages
+- Optimized queries in case of `SELECT *`
+- Database is clean and doesn't have anything hidden or redundant data
+
+## Options
+
+ - `--format`, `-f` Set output format. Available options are JSON and TEXT.
+   Defaults to TEXT.
+
+## Flags
+
+ - `--dry-run` Show what would be deleted
+ - `--no-backup` Do not backup the site. This is not recommended since this is a
+   destructive operation.
+
+### Examples
+
+1. There maybe a lot of lingering columns taking up the space. Perhaps you figured this out
+    when you got an error that row size limit has reached while customizing your DocType. To
+    be sure that there aren't any ghost columns, or old hidden fields taking up the space, you
+    can be sure by running
+
+    ```bash
+    bench --site {site} trim-tables --dry-run
+    ```


### PR DESCRIPTION
### Changes

- Removed command references from CLI sidebar. Moved into a separate page (index)
- Added command to make it easier to write command references using a template: `bench add-command-reference [COMMAND]` in frappe_docs.
- Added docs for https://github.com/frappe/frappe/pull/13954
  - bench db-console
  - bench transform-database
- Added docs for https://github.com/frappe/frappe/pull/13955
  - trim-tables
  - trim-database