### PR TITLE
fix: add `safe_render` flag in `qunit-testing`

### DIFF
--- a/frappe_docs/www/docs/user/en/guides/automated-testing/qunit-testing.md
+++ b/frappe_docs/www/docs/user/en/guides/automated-testing/qunit-testing.md
@@ -7,7 +7,7 @@ safe_render: false
 
 You can either write integration tests, or directly write tests in Javascript using [QUnit](http://api.qunitjs.com/)
 
-QUnit helps you write UI tests using the UQuit framework and native frappe API. As you might have guessed, this is a much faster way of writing tests.
+QUnit helps you write UI tests using the QUnit framework and native frappe API. As you might have guessed, this is a much faster way of writing tests.
 
 ### Test Runner
 

--- a/frappe_docs/www/docs/user/en/guides/automated-testing/qunit-testing.md
+++ b/frappe_docs/www/docs/user/en/guides/automated-testing/qunit-testing.md
@@ -1,4 +1,8 @@
 <!-- add-breadcrumbs -->
+---
+safe_render: false
+---
+
 # UI Testing with Frappe API
 
 You can either write integration tests, or directly write tests in Javascript using [QUnit](http://api.qunitjs.com/)


### PR DESCRIPTION
This PR will fix the [qunit-testing](https://frappeframework.com/docs/user/en/guides/automated-testing/qunit-testing) broken page.

---

fixes: https://github.com/frappe/frappe_docs/issues/148