### PR TITLE
feat: custom database port for read-only replica configuration

### DIFF
--- a/frappe_docs/www/docs/user/en/basics/site_config.md
+++ b/frappe_docs/www/docs/user/en/basics/site_config.md
@@ -169,7 +169,16 @@ must be set for Frappe to attempt to connect using SSL.
 
 ### Replica Read Only Database Host Settings
 
-An example of how to do this is available at [Setup read operations from slave/secondary mysql system](https://frappeframework.com/docs/user/en/guides/database-settings/setup-read-from-secondary-db).
+Guide to setup read operations from secondary MariaDB server in a replica setup is available at in the [user guides](/docs/user/en/guides/database-settings/setup-read-from-secondary-db).
+
+| | |
+| ----------- | ----------- |
+| `read_from_replica` | To enable disable read from replica. Acceptable values are 1/0 or true/false. |
+| `different_credentials_for_replica` | If database credentials are different on replica then set 1 else 0 |
+| `replica_host` | IP address for repica |
+| `replica_db_name` | Replica DB name |
+| `replica_db_password` | Replica DB password |
+
 
 ### Default Outgoing Email Settings
 

--- a/frappe_docs/www/docs/user/en/basics/site_config.md
+++ b/frappe_docs/www/docs/user/en/basics/site_config.md
@@ -167,6 +167,10 @@ must be set for Frappe to attempt to connect using SSL.
 | `db_ssl_key` | Full path to the key.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/client-key.pem"`. |
 | `rds_db` | Grant certain privileges instead of all, while setting up a Site's database. Used in `db_manager.py`. |
 
+### Replica Read Only Database Host Settings
+
+An example of how to do this is available at [Setup read operations from slave/secondary mysql system](https://frappeframework.com/docs/user/en/guides/database-settings/setup-read-from-secondary-db).
+
 ### Default Outgoing Email Settings
 
 Some of the available lower level configurations for Frappe's Email module.

--- a/frappe_docs/www/docs/user/en/guides/database-settings/setup-read-from-secondary-db.md
+++ b/frappe_docs/www/docs/user/en/guides/database-settings/setup-read-from-secondary-db.md
@@ -21,6 +21,7 @@ Now, in frappe, you can split read and write activities between master and repli
 		"read_from_replica"                 : 1/0  # to enable disable read from replica
 		"different_credentials_for_replica" : 1/0 #if database creadetials are different on replica then set 1 else 0
 		"replica_host"                      : "IP address for repica" ,
+		"replica_db_port"                   : "Replica DB port",
 		"replica_db_name"                   : "Replica DB name",
 		"replica_db_password"               : "Replica DB password",
 		...
@@ -29,5 +30,3 @@ Now, in frappe, you can split read and write activities between master and repli
 	**Note**: If you have enabled MariaDB master-replica environment, then DB name and DB password are same on both.
 
 3. [Grant access permissions](https://dev.mysql.com/doc/refman/8.0/en/grant.html) for master host on slave / secondary system.
-
-

--- a/frappe_docs/www/docs/user/en/guides/database-settings/setup-read-from-secondary-db.md
+++ b/frappe_docs/www/docs/user/en/guides/database-settings/setup-read-from-secondary-db.md
@@ -20,7 +20,7 @@ Now, in frappe, you can split read and write activities between master and repli
 		...
 		"read_from_replica"                 : 1/0  # to enable disable read from replica
 		"different_credentials_for_replica" : 1/0 #if database creadetials are different on replica then set 1 else 0
-		"replica_host"                      : "IP address for repica" ,
+		"replica_host"                      : "IP address for replica" ,
 		"replica_db_port"                   : "Replica DB port",
 		"replica_db_name"                   : "Replica DB name",
 		"replica_db_password"               : "Replica DB password",


### PR DESCRIPTION
Docs for frappe pr https://github.com/frappe/frappe/pull/14159 added in /docs/user/en/basics/site_config and /docs/user/en/guides/database-settings/setup-read-from-secondary-db