### PR TITLE
docs: add proper way to  submit/cancel

### DIFF
--- a/frappe_docs/www/docs/user/en/api/rest.md
+++ b/frappe_docs/www/docs/user/en/api/rest.md
@@ -373,6 +373,19 @@ Response
 {"message": "ok"}
 ```
 
+### Submitting / Cancelling a document
+
+Submit/Cancel action can be performed by making a `POST` request to
+`/api/resource/:doctype/:name` with required method.
+
+```sh
+POST /api/resource/:doctype/:name
+
+# body
+{ "run_method": "submit" }
+```
+
+
 ## Remote Method Calls
 
 Frappe allows you to trigger arbitrary python methods using the REST API for


### PR DESCRIPTION
Often in the community, this is recommended for cancelling/submitting:

```sh
PUT /api/resource/doctype/name 
{"docstatus": 2}
```

If you read `document.py` this isn't really equivalent to cancelling the document. IMO the current best method is to supply `run_method` (both submit/cancel are whitelisted). 



---

I am not fully sure about this, maybe this would be better?

```
POST /api/resource/doctype/name/cancel
```